### PR TITLE
Fix/240915 feedback qa

### DIFF
--- a/core/static/core/js/uploader.js
+++ b/core/static/core/js/uploader.js
@@ -1,4 +1,13 @@
-function actionWork(action, work_id)   {
+function actionWork(btn)   {
+    $('#accept_all').prop('disabled', true);
+    $('#accept_all').addClass('btn-disabled');
+    $('#reject_all').prop('disabled', true);
+    $('#reject_all').addClass('btn-disabled');
+
+    let action = btn.name.split('_')[0];
+    let work_id = btn.name.split('_')[1];
+
+    $('#review').hide(400);
     $('#confirm').show(400);
     $('#action').val(action);
     $('#work_id').val(work_id);
@@ -12,4 +21,13 @@ function actionWork(action, work_id)   {
     else {
         $('#confirm_title').text(action + ' the following ' + work_count + ' works?');
     }
+}
+
+function cancelActionWork() {
+    $('#confirm').hide(400);
+    $('#review').show(400);
+    $('#accept_all').prop('disabled', false);
+    $('#accept_all').removeClass('btn-disabled');
+    $('#reject_all').prop('disabled', false);
+    $('#reject_all').removeClass('btn-disabled');
 }

--- a/core/static/core/scss/components/button.scss
+++ b/core/static/core/scss/components/button.scss
@@ -33,3 +33,15 @@
     color: $white;
   }
 }
+
+.btn-disabled {
+    background-color: gray;
+    pointer-events: none;
+
+    &:hover, &:focus, &:active {
+        background-color: inherit;
+        border-color: inherit;
+        color: inherit;
+}
+
+}

--- a/uploader/models.py
+++ b/uploader/models.py
@@ -365,7 +365,7 @@ class CofkCollectWork(models.Model):
     mentioned_uncertain = models.SmallIntegerField(default=0)
     notes_on_destination = models.TextField(blank=True, null=True)
     notes_on_origin = models.TextField(blank=True, null=True)
-    notes_on_place_mentioned = models.TextField(blank=True, null=True)
+    notes_on_place_mentioned = models.TextField(blank=True, null=True) # this field does not appear to be used
     place_mentioned_as_marked = models.TextField(blank=True, null=True)
     place_mentioned_inferred = models.SmallIntegerField(default=0)
     place_mentioned_uncertain = models.SmallIntegerField(default=0)

--- a/uploader/review.py
+++ b/uploader/review.py
@@ -184,7 +184,7 @@ def accept_works(context: dict, upload: CofkCollectUpload, request=None, email_a
         msg = f'No works in the upload "{upload.upload_name}" can be accepted (was the page refreshed?).'
         if request:
             messages.error(request, msg)
-        else:
+        elif email_addresses:
             try:
                 email_utils.send_email(email_addresses,
                                        subject='EMLO Works Accepted Result',

--- a/uploader/review.py
+++ b/uploader/review.py
@@ -45,6 +45,13 @@ def create_union_work(union_work_dict: dict, collect_work: CofkCollectWork, user
             # log.warning(f'Field {field} does not exist')
             pass
 
+    # EMLO Collect does not set the boolean date_of_work_std_is_range to true
+    # if a second date is set. Therefore, we need to check if there are any values set
+    # for the second date.
+    # Note that this makes it a minimum requirement that the year be set for the second date.
+    if not collect_work.date_of_work_std_is_range and collect_work.date_of_work2_std_year:
+        union_work_dict['date_of_work_std_is_range'] = 1
+
     union_work = CofkUnionWork(**union_work_dict)
     union_work.update_current_user_timestamp(username)
 

--- a/uploader/templates/uploader/component/confirm.html
+++ b/uploader/templates/uploader/component/confirm.html
@@ -37,7 +37,7 @@
         <input type="hidden" value="" name="action" id="action"/>
 
         <button class="btn inline_btn" name="confirm">Confirm</button>
-        <button type="button" class="btn inline_btn" onclick="$('#confirm').hide(400);">Cancel</button>
+        <button type="button" class="btn inline_btn" onclick="cancelActionWork();">Cancel</button>
     </div>
 </fieldset>
 </form>

--- a/uploader/templates/uploader/component/list_person.html
+++ b/uploader/templates/uploader/component/list_person.html
@@ -3,19 +3,19 @@
 {% endif %}
 
     {% for person in people %}
-    {% if people|length > 1 %}
-    <li>
-    {% endif %}
-
-        {% if person.iperson.union_iperson %}
-        <u>{{ person.iperson.union_iperson.foaf_name }}</u>
-        {% else %}
-        <u>{{ person.iperson.primary_name }} (collect)</u>
+        {% if people|length > 1 %}
+        <li>
         {% endif %}
 
-    {% if people|length > 1 %}
-    </li>
-    {% else %}
+        {% if person.iperson.union_iperson %}
+            <u>{{ person.iperson.union_iperson.foaf_name }}</u>
+        {% else %}
+            <u>{{ person.iperson.primary_name }} (collect)</u>
+        {% endif %}
+
+        {% if people|length > 1 %}
+        </li>
+        {% else %}
     <br/>
     {% endif %}
 

--- a/uploader/templates/uploader/component/list_place.html
+++ b/uploader/templates/uploader/component/list_place.html
@@ -1,0 +1,28 @@
+{% if places|length > 1 %}
+<ul>
+{% endif %}
+
+    {% for place in places %}
+        {% if places|length > 1 %}
+        <li>
+        {% endif %}
+
+        {% if place.iperson.union_iperson %}
+            <u>{{ place.location.union_location.location_name }}</u>
+        {% else %}
+            <u>{{ place.location.location_name }} (collect)</u>
+        {% endif %}
+
+        {% if places|length > 1 %}
+        </li>
+        {% else %}
+    <br/>
+    {% endif %}
+
+    {% endfor %}
+{% if places|length > 1 %}
+</ul>
+
+{% else %}
+<br/>
+{% endif %}

--- a/uploader/templates/uploader/component/people.html
+++ b/uploader/templates/uploader/component/people.html
@@ -18,30 +18,63 @@
         <td class="header">Primary name</td>
         <td>{{ person.primary_name }}</td>
     </tr>
+
     {% if person.gender %}
     <tr>
         <td class="header">Gender</td>
         <td>{{ person.gender }}</td>
     </tr>
     {% endif %}
+
     {% if person.roles_or_titles %}
     <tr>
         <td class="header">Roles or titles</td>
         <td>{{ person.roles_or_titles }}</td>
     </tr>
     {% endif %}
+
     {% if person.date_of_birth_year %}
     <tr>
         <td class="header">Date of birth</td>
         <td>{{ person.date_of_birth_year }}</td>
     </tr>
     {% endif %}
+
     {% if person.date_of_death_year %}
     <tr>
         <td class="header">Date of death</td>
         <td>{{ person.date_of_death_year }}</td>
     </tr>
     {% endif %}
+
+    {% if person.flourished_year %}
+    <tr>
+        <td class="header">Flourished from</td>
+        <td>{{ person.flourished_year }}</td>
+    </tr>
+    {% endif %}
+
+    {% if person.flourished2_year %}
+    <tr>
+        <td class="header">Flourished to</td>
+        <td>{{ person.flourished2_year }}</td>
+    </tr>
+    {% endif %}
+
+    {% if person.notes_on_person %}
+    <tr>
+        <td class="header">Notes on person</td>
+        <td>{{ person.notes_on_person }}</td>
+    </tr>
+    {% endif %}
+
+    {% if person.editors_notes %}
+    <tr>
+        <td class="header">Editors' notes</td>
+        <td>{{ person.editors_notes }}</td>
+    </tr>
+    {% endif %}
+
 </table>
 
 {% endfor %}

--- a/uploader/templates/uploader/component/places.html
+++ b/uploader/templates/uploader/component/places.html
@@ -18,6 +18,91 @@
         <td class="header">Location name</td>
         <td>{{ location.location_name }}</td>
     </tr>
+
+    {% if location.element_1_eg_room %}
+    <tr>
+        <td class="header">Room</td>
+        <td>{{ location.element_1_eg_room }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.element_2_eg_building %}
+    <tr>
+        <td class="header">Building</td>
+        <td>{{ location.element_2_eg_building }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.element_3_eg_parish %}
+    <tr>
+        <td class="header">Parish</td>
+        <td>{{ location.element_3_eg_parish }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.element_4_eg_city %}
+    <tr>
+        <td class="header">City</td>
+        <td>{{ location.element_4_eg_city }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.element_5_eg_county %}
+    <tr>
+        <td class="header">County</td>
+        <td>{{ location.element_5_eg_county }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.element_6_eg_country %}
+    <tr>
+        <td class="header">Country</td>
+        <td>{{ location.element_6_eg_country }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.element_7_eg_empire %}
+    <tr>
+        <td class="header">Empire</td>
+        <td>{{ location.element_7_eg_empire }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.notes_on_place %}
+    <tr>
+        <td class="header">Notes on place</td>
+        <td>{{ location.notes_on_place }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.editors_notes %}
+    <tr>
+        <td class="header">Editors' notes</td>
+        <td>{{ location.editors_notes }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.location_synonyms %}
+    <tr>
+        <td class="header">Synonyms</td>
+        <td>{{ location.location_synonyms }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.latitude %}
+    <tr>
+        <td class="header">Latitude</td>
+        <td>{{ location.latitude }}</td>
+    </tr>
+    {% endif %}
+
+    {% if location.longitude %}
+    <tr>
+        <td class="header">Longitude</td>
+        <td>{{ location.longitude }}</td>
+    </tr>
+    {% endif %}
+
 </table>
 
 {% endfor %}

--- a/uploader/templates/uploader/component/work.html
+++ b/uploader/templates/uploader/component/work.html
@@ -168,6 +168,21 @@
 </tr>
 {% endif %}
 
+{% if work.places_mentioned.all %}
+<tr>
+    <td class="header">{{ work.places_mentioned.all|pluralize:"Place,Places" }} mentioned</td>
+    <td>
+
+        {% include "uploader/component/list_place.html" with places=work.places_mentioned.all %}
+
+        {% if work.place_mentioned_as_marked %}
+        As marked: {{ work.place_mentioned_as_marked }}<br/>
+        {% endif %}
+
+    </td>
+</tr>
+{% endif %}
+
 {% if work.manifestations.all %}
 <tr>
     <td class="header">Repositories and versions</td>

--- a/uploader/templates/uploader/component/work.html
+++ b/uploader/templates/uploader/component/work.html
@@ -146,7 +146,14 @@
 </tr>
 {% endif %}
 
-{% if work.people_mentioned.all %}
+{% comment %}
+It is possible throught EMLO Collect to put in a note on people mentioned,
+yet not actually add any people mentioned.
+
+The same does not apply to notes on places mentioned, which is not used at all
+{% endcomment %}
+
+{% if work.people_mentioned.all or work.notes_on_people_mentioned %}
 <tr>
     <td class="header">{{ work.people_mentioned.all|pluralize:"Person,People" }} mentioned</td>
     <td>

--- a/uploader/templates/uploader/component/work.html
+++ b/uploader/templates/uploader/component/work.html
@@ -147,7 +147,7 @@
 {% endif %}
 
 {% comment %}
-It is possible throught EMLO Collect to put in a note on people mentioned,
+It is possible through EMLO Collect to put in a note on people mentioned,
 yet not actually add any people mentioned.
 
 The same does not apply to notes on places mentioned, which is not used at all

--- a/uploader/templates/uploader/component/works.html
+++ b/uploader/templates/uploader/component/works.html
@@ -47,10 +47,10 @@
         <td class="header">Status and possible actions</td>
         <td><strong>{{ work.upload_status }}</strong> (Collect ID: {{ work.iwork_id }})<br/>
             {% if work.upload_status_id == 1 %}
-            <button name="accept_work" class="btn inline_btn" onclick="actionWork('accept', {{ work.iwork_id }});">
+            <button name="accept_{{ work.iwork_id }}" class="btn inline_btn" onclick="actionWork(this);">
                 Accept
             </button>
-            <button name="reject_work" class="btn inline_btn" onclick="actionWork('reject', {{ work.iwork_id }});">
+            <button name="reject_{{ work.iwork_id }}" class="btn inline_btn" onclick="actionWork(this);">
                 Reject
             </button>
             <br/>

--- a/uploader/templates/uploader/review.html
+++ b/uploader/templates/uploader/review.html
@@ -13,10 +13,10 @@
         <button type="button" class="btn inline_btn" onclick="location.href='/upload'">Back</button>
 
         Accept entire contribution
-        <button class="btn inline_btn" name="accept_all" onclick="actionWork('accept', 'all');">Accept all</button>
+        <button class="btn inline_btn" id="accept_all" name="accept_all" onclick="actionWork(this);">Accept all</button>
 
         Reject entire contribution
-        <button class="btn inline_btn" name="reject_all" onclick="actionWork('reject', 'all');">Reject all</button>
+        <button class="btn inline_btn" id="reject_all" name="reject_all" onclick="actionWork(this);" disabled>Reject all</button>
     </div>
     <em>Note: confirmation will be required before Accept/Reject of entire contribution.</em>
 </div>
@@ -25,16 +25,18 @@
 
 {% include "uploader/component/confirm.html" %}
 
-{% include "uploader/component/works.html" %}
+<div id="review">
+    {% include "uploader/component/works.html" %}
 
-{% if people %}
-{% include "uploader/component/people.html" %}
-{% endif %}
+    {% if people %}
+    {% include "uploader/component/people.html" %}
+    {% endif %}
 
-{% if places %}
-{% include "uploader/component/places.html" %}
-{% endif %}
+    {% if places %}
+    {% include "uploader/component/places.html" %}
+    {% endif %}
 
+</div>
 <!--
 {% for institution in institutions %}
 

--- a/uploader/templates/uploader/review.html
+++ b/uploader/templates/uploader/review.html
@@ -16,7 +16,7 @@
         <button class="btn inline_btn" id="accept_all" name="accept_all" onclick="actionWork(this);">Accept all</button>
 
         Reject entire contribution
-        <button class="btn inline_btn" id="reject_all" name="reject_all" onclick="actionWork(this);" disabled>Reject all</button>
+        <button class="btn inline_btn" id="reject_all" name="reject_all" onclick="actionWork(this);">Reject all</button>
     </div>
     <em>Note: confirmation will be required before Accept/Reject of entire contribution.</em>
 </div>

--- a/uploader/test/test_review.py
+++ b/uploader/test/test_review.py
@@ -2,10 +2,14 @@ import logging
 import re
 
 from django.core.exceptions import PermissionDenied
+from django.core.paginator import Paginator
 
 from core.constant import REL_TYPE_CREATED
+from uploader.models import CofkCollectUpload
+from uploader.review import accept_works
 from uploader.spreadsheet import CofkUploadExcelFile
 from uploader.test.test_serv import UploadIncludedFactoryTestCase, spreadsheet_data, upload_status, MockMessages
+from uploader.uploader_serv import DisplayableCollectWork
 from uploader.views import upload_review
 from work.models import CofkUnionWork
 
@@ -42,25 +46,28 @@ class TestReview(UploadIncludedFactoryTestCase):
 
     def test_accept_upload(self):
         filename = self.create_excel_file(spreadsheet_data)
-
+        prefetch = ['authors', 'addressees', 'people_mentioned', 'languages', 'subjects', 'manifestations', 'resources',
+                    'upload_status', 'addressees__iperson', 'authors__iperson', 'people_mentioned__iperson',
+                    'manifestations__repository', 'authors__iperson__union_iperson',
+                    'addressees__iperson__union_iperson', 'origin__location', 'destination__location',
+                    'origin__location__union_location', 'destination__location__union_location',
+                    'languages__language_code']
         cuef = CofkUploadExcelFile(self.new_upload, filename)
 
-        request = self.factory.post("/upload", {'work_id': 'all', 'action': 'accept', 'confirm': ''})
-        request.user = self.admin
-        request._messages = MockMessages()
+        works_paginator = Paginator(DisplayableCollectWork.objects.filter(upload=self.new_upload)
+                                    .prefetch_related(*prefetch).order_by('pk'), 1000)
 
-        response = upload_review(request, self.new_upload.upload_id)
+        context = { 'work_id': 'all', 'works_page': works_paginator.get_page(1), 'username': self.admin.username }
 
-        match = re.search(upload_status, str(response.content))
+        accept_works(context, self.new_upload)
+        name_of_first_author = next(CofkUnionWork.objects.first().find_persons_by_rel_type(REL_TYPE_CREATED)).foaf_name
 
         self.assertEqual(cuef.errors, {})
-        self.assertEqual(match.group('status'), 'Review complete')
-        self.assertEqual(match.group('works'), '1')
-        self.assertEqual(match.group('accepted'), '1')
-        self.assertEqual(match.group('rejected'), '0')
-
-        self.assertEqual(next(CofkUnionWork.objects.all()[0].find_persons_by_rel_type(REL_TYPE_CREATED)).foaf_name,
-                         'Newton')
+        self.assertEqual(self.new_upload.upload_status.status_id, 3)
+        self.assertEqual(self.new_upload.total_works, 1)
+        self.assertEqual(self.new_upload.works_accepted, 1)
+        self.assertEqual(self.new_upload.works_rejected, 0)
+        self.assertEqual(name_of_first_author, 'Newton')
 
     def test_reject_upload(self):
         filename = self.create_excel_file(spreadsheet_data)

--- a/uploader/uploader_serv.py
+++ b/uploader/uploader_serv.py
@@ -42,7 +42,7 @@ class DisplayableCollectWork(CofkCollectWork):
 
     @property
     def display_date(self) -> str | None:
-        if self.date_of_work_std_is_range == 0:
+        if not self.date_of_work2_std:
             return self.date_of_work_std
         elif self.date_of_work_std and self.date_of_work2_std:
             return f'{self.date_of_work_std} to {self.date_of_work2_std}'


### PR DESCRIPTION
This PR fixes all of the issues raised in Miranda's document `QAserver_UPLOAD_REVIEW_2024.9.15_ML.docx` except for:

 **ISSUE**

The page listing the uploads doesn't refresh automatically, and you have to refresh the page manually to ensure the dataset listing of what you've uploaded to EMLO-Edit2 is removed from the list.

Issues spotted when reviewing the Uploaded dataset in EMLO-Edit2
**ISSUE**
When I come to check the letter(s) I've uploaded, I find that the test catalogue I've created ' Test, Upload1' doesn't show up in the drop down list in 'Search Works' > field of 'Original catalogue', so I'm unable to search for the new upload that way. 
Please will you look at this failure of newly created catalogue names to appear in the works search (for your info. I did try refreshing the page), as searching by the catalogue name in EMLO-Edit is used very often. Thanks.

In addition I have made the code more resilient to failures by wrapping the creation of Union entities inside a Django [database transaction](https://docs.djangoproject.com/en/5.1/topics/db/transactions/) so that if an exception occurs, all created entities are rolled back.

I have not written unit tests, because of time constraints.