### PR TITLE
Validate manifestation type

### DIFF
--- a/uploader/entities/manifestations.py
+++ b/uploader/entities/manifestations.py
@@ -2,6 +2,7 @@ import logging
 from abc import ABC
 from typing import List
 
+from core.helper import query_cache_serv
 from uploader.entities.entity import CofkEntity
 from uploader.models import CofkCollectUpload, CofkCollectManifestation, CofkCollectWork, CofkCollectInstitution
 
@@ -19,6 +20,8 @@ class CofkManifestations(CofkEntity, ABC):
         self.repositories = repositories
         self.works = works
         self.manifestations: List[CofkCollectManifestation] = []
+        self.lookup_doc_desc_map = query_cache_serv.create_lookup_doc_desc_map()
+
 
         for index, row in enumerate(self.sheet.worksheet.iter_rows(), start=1):
             man_dict = self.get_row(row, index)
@@ -53,6 +56,13 @@ class CofkManifestations(CofkEntity, ABC):
             # TODO can this be right?
             if 'manifestation_type_p' in man_dict:
                 man_dict['manifestation_type'] = man_dict.pop('manifestation_type_p')
+
+            if 'manifestation_type' in man_dict:
+                if man_dict['manifestation_type'] not in self.lookup_doc_desc_map:
+                    self.add_error(
+                        f'manifestation_type "{man_dict["manifestation_type"]}" is not a valid document type. '
+                        f'Valid values: {list(self.lookup_doc_desc_map.keys())}'
+                    )
 
             if 'repository_name' in man_dict:
                 del man_dict['repository_name']

--- a/uploader/test/test_manifestations.py
+++ b/uploader/test/test_manifestations.py
@@ -1,0 +1,65 @@
+import logging
+
+from uploader.spreadsheet import CofkUploadExcelFile
+from uploader.test.test_serv import UploadIncludedTestCase, spreadsheet_data
+
+log = logging.getLogger(__name__)
+
+
+class TestManifestations(UploadIncludedTestCase):
+
+    def test_valid_manifestation_type(self):
+        """
+        A manifestation_type value that exists in the lookup map should produce no error.
+        """
+        data = {**spreadsheet_data, 'Manifestation': [
+            [1, 1, "ALS", 1, "Bodleian", "test", "test", '', '', '', '', ''],
+        ]}
+        filename = self.create_excel_file(data)
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertNotIn('manifestations', cuef.errors)
+
+    def test_invalid_manifestation_type(self):
+        """
+        A manifestation_type value that does not exist in the lookup map should produce an error.
+        """
+        data = {**spreadsheet_data, 'Manifestation': [
+            [1, 1, "XXX", 1, "Bodleian", "test", "test", '', '', '', '', ''],
+        ]}
+        filename = self.create_excel_file(data)
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertIn('manifestations', cuef.errors)
+        self.assertIn('XXX', cuef.errors['manifestations']['errors'][0]['errors'][0])
+
+    def test_valid_manifestation_type_p(self):
+        """
+        A manifestation_type_p value that exists in the lookup map should produce no error
+        after being remapped to manifestation_type.
+        """
+        data = {**spreadsheet_data, 'Manifestation': [
+            [1, 1, '', '', '', '', '', "P", "test", "test", '', ''],
+        ]}
+        filename = self.create_excel_file(data)
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertNotIn('manifestations', cuef.errors)
+
+    def test_invalid_manifestation_type_p(self):
+        """
+        A manifestation_type_p value that does not exist in the lookup map should produce an error,
+        since it is remapped to manifestation_type before validation.
+        """
+        data = {**spreadsheet_data, 'Manifestation': [
+            [1, 1, '', '', '', '', '', "INVALID", "test", "test", '', ''],
+        ]}
+        filename = self.create_excel_file(data)
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertIn('manifestations', cuef.errors)
+        self.assertIn('INVALID', cuef.errors['manifestations']['errors'][0]['errors'][0])

--- a/uploader/test/test_serv.py
+++ b/uploader/test/test_serv.py
@@ -10,7 +10,7 @@ from openpyxl.workbook import Workbook
 
 from core import constant
 from core.helper import perm_serv
-from core.models import Iso639LanguageCode
+from core.models import CofkLookupDocumentType, Iso639LanguageCode
 from institution.models import CofkUnionInstitution
 from location.models import CofkUnionLocation
 from login.models import CofkUser
@@ -89,6 +89,9 @@ class UploadIncludedTestCase(UploaderTestCase):
 
         for loc in [782, 400285]:
             CofkUnionLocation(pk=loc).save()
+
+        for code, desc in [('ALS', 'Autograph Letter Signed'), ('P', 'Printed')]:
+            CofkLookupDocumentType.objects.create(document_type_code=code, document_type_desc=desc)
 
         for lang in ['eng', 'fra']:
             Iso639LanguageCode(code_639_3=lang).save()


### PR DESCRIPTION
Related to [Manifestation type should be normalized](https://github.com/culturesofknowledge/emlo-project/issues/251)

This PR adds a check for uploaded manifestations that the `manifestation_type` is of a value that's in the lookup table for it.

As a related issue, should the value for '`manifestation_type_p`' be cast to '`manifestation_type`'.