### PR TITLE
Feature/upload locations people

### DIFF
--- a/core/helper/uploader_serv.py
+++ b/core/helper/uploader_serv.py
@@ -66,6 +66,7 @@ def handle_upload(upload: CofkCollectUpload, email_results: bool = False, file_n
 
     try:
         cuef = CofkUploadExcelFile(upload, file)
+        upload.upload_type = cuef.upload_type
 
         elapsed = round(time.time() - start)
 

--- a/core/static/core/scss/components/upload.scss
+++ b/core/static/core/scss/components/upload.scss
@@ -1,5 +1,5 @@
 div#upload-header {
-  margin-top: 100px;
+  //margin-top: 100px;
 }
 
 span#upload-title {

--- a/core/static/core/scss/components/upload.scss
+++ b/core/static/core/scss/components/upload.scss
@@ -2,7 +2,13 @@ div#upload-header {
   margin-top: 100px;
 }
 
+span#upload-title {
+  font-size: 1.5em;
+  color: #333333;
+}
+
 span#upload-summary {
+  display: block;
   background-color: $light-grey;
   font-weight: bold;
   padding: $space-xs;

--- a/core/static/core/scss/emlo-common.scss
+++ b/core/static/core/scss/emlo-common.scss
@@ -580,7 +580,9 @@ h2, h3 {
     border-left: 3px solid #007bff;
 }
 
-
+.messages {
+  clear: both;
+}
 
 // Suggestion filter styling: add left/right padding and improve spacing/legibility
 #f_filter {

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,17 @@
 import os
 import sys
 
+import django.utils.version as _v, traceback as _tb                                                                                                                                                      
+_orig = _v.get_complete_version                           
+def _watch(version=None):                                                                                                                                                                                
+    if version is not None and len(version) != 5:         
+        print(f'\n!!! BAD VERSION: {version!r}')                                                                                                                                                         
+        _tb.print_stack(limit=20)
+        raise RuntimeError(f'Bad version: {version!r}')                                                                                                                                                  
+    return _orig(version)                                                                                                                                                                                
+_v.get_complete_version = _watch
+
+
 
 def main():
     """Run administrative tasks."""

--- a/uploader/constants.py
+++ b/uploader/constants.py
@@ -174,7 +174,7 @@ BULK_LOCATIONS_SHEET = {
         'resource_url',         # 14 RELATED RESOURCE URL
     ],
     'required': [],
-    'strings': ['element_4_eg_city', 'element_5_eg_county', 'element_6_eg_country',
-                'element_3_eg_parish', 'element_2_eg_building', 'element_1_eg_room',
-                'element_7_eg_empire', 'location_synonyms', 'notes_on_place', 'editors_notes'],
+    'strings': [('element_4_eg_city', 100), ('element_5_eg_county', 100), ('element_6_eg_country', 100),
+                ('element_3_eg_parish', 100), ('element_2_eg_building', 100), ('element_1_eg_room', 100),
+                ('element_7_eg_empire', 100), 'location_synonyms', 'notes_on_place', 'editors_notes'],
 }

--- a/uploader/constants.py
+++ b/uploader/constants.py
@@ -61,7 +61,7 @@ MANDATORY_SHEETS = {
                     'abstract', 'keywords', 'language_id', 'language_of_work', 'hasgreek', 'hasarabic', 'hashebrew',
                     'haslatin', 'answererby', 'incipit', 'explicit', 'notes_on_letter', 'mention_id', 'emlo_mention_id',
                     'notes_on_people_mentioned', 'editors_notes', 'resource_name', 'resource_url', 'resource_details'],
-        'ids': ['iwork_id', 'author_ids', 'addressee_ids', 'origin_id', 'emlo_mention_id'],
+        'ids': ['iwork_id', 'author_ids', 'addressee_ids', 'origin_id', 'destination_id', 'emlo_mention_id'],
         'ints': ['iwork_id', 'date_of_work_std_year', 'date_of_work_std_month', 'date_of_work_std_day',
                  'date_of_work2_std_year', 'date_of_work2_std_month', 'date_of_work2_std_day', 'origin_id',
                  'destination_id'],

--- a/uploader/constants.py
+++ b/uploader/constants.py
@@ -113,3 +113,68 @@ MANDATORY_SHEETS = {
 
 MAX_YEAR = 1900
 MIN_YEAR = 1400
+
+# Column definitions for bulk People upload (BULKnewPEOPLErecordsTEMPLATE format).
+# Columns are mapped by position (index) rather than by matching header text, because the
+# template uses verbose human-readable column headers.
+BULK_PEOPLE_SHEET = {
+    'columns': [
+        'primary_name',            # 1  Primary name
+        'alternative_names',       # 2  Synonyms
+        'roles_or_titles',         # 3  Occupations / roles / titles
+        'gender',                  # 4  GENDER
+        'is_organisation',         # 5  IS ORGANIZATION
+        'date_of_birth_year',      # 6  BIRTH YEAR / FOUNDATION YEAR IF ORG
+        'date_of_birth_inferred',  # 7  BIRTH YEAR INFERRED
+        'date_of_birth_uncertain', # 8  BIRTH YEAR UNCERTAIN
+        'date_of_birth_approx',    # 9  BIRTH YEAR APPROX
+        'date_of_death_year',      # 10 DEATH YEAR / DISBAND YEAR IF ORG
+        'date_of_death_inferred',  # 11 DEATH YEAR INFERRED
+        'date_of_death_uncertain', # 12 DEATH YEAR UNCERTAIN
+        'date_of_death_approx',    # 13 DEATH YEAR APPROX
+        'flourished_year',         # 14 FLOURISHED EARLIEST YEAR 1
+        'flourished2_year',        # 15 FLOURISHED LATEST YEAR 2
+        'flourished_is_range',     # 16 FLOURISHED IS RANGE
+        '_flourished_inferred',    # 17 FLOURISHED YEAR INFERRED (no model field)
+        '_flourished_uncertain',   # 18 FLOURISHED YEAR UNCERTAIN (no model field)
+        '_flourished_approx',      # 19 FLOURISHED YEAR APPROX (no model field)
+        'notes_on_person',         # 20 GENERAL NOTES ON PERSON
+        'editors_notes',           # 21 EDITORS' NOTES AND QUERIES
+        'resource_name',           # 22 RELATED RESOURCE NAME
+        'resource_url',            # 23 RELATED RESOURCE URL
+        '_further_reading',        # 24 Further reading (no model field)
+    ],
+    'required': ['primary_name'],
+    'strings': [('primary_name', 200), ('gender', 1), ('is_organisation', 1),
+                'alternative_names', 'roles_or_titles', 'notes_on_person', 'editors_notes'],
+    'ints': ['date_of_birth_year', 'date_of_death_year', 'flourished_year', 'flourished2_year'],
+    'bools': ['date_of_birth_inferred', 'date_of_birth_uncertain', 'date_of_birth_approx',
+              'date_of_death_inferred', 'date_of_death_uncertain', 'date_of_death_approx',
+              'flourished_is_range'],
+    'years': ['date_of_birth_year', 'date_of_death_year', 'flourished_year', 'flourished2_year'],
+}
+
+# Column definitions for bulk Locations upload (BULKnewLOCATIONrecordsTEMPLATE format).
+# Columns are mapped by position (index) rather than by matching header text.
+BULK_LOCATIONS_SHEET = {
+    'columns': [
+        'element_4_eg_city',    # 1  Name of City/town/village
+        'element_5_eg_county',  # 2  Name of County
+        'element_6_eg_country', # 3  Name of Country
+        'element_3_eg_parish',  # 4  Name of District of city
+        'element_2_eg_building',# 5  Name of Building
+        'element_1_eg_room',    # 6  Name of Room
+        'element_7_eg_empire',  # 7  Name of Empire
+        'location_synonyms',    # 8  Synonyms / Alternative names
+        'latitude',             # 9  LATITUDE
+        'longitude',            # 10 LONGITUDE
+        'notes_on_place',       # 11 GENERAL NOTES ON PLACE
+        'editors_notes',        # 12 EDITORS' NOTES AND QUERIES
+        'resource_name',        # 13 RELATED RESOURCE NAME
+        'resource_url',         # 14 RELATED RESOURCE URL
+    ],
+    'required': [],
+    'strings': ['element_4_eg_city', 'element_5_eg_county', 'element_6_eg_country',
+                'element_3_eg_parish', 'element_2_eg_building', 'element_1_eg_room',
+                'element_7_eg_empire', 'location_synonyms', 'notes_on_place', 'editors_notes'],
+}

--- a/uploader/entities/entity.py
+++ b/uploader/entities/entity.py
@@ -99,7 +99,7 @@ class CofkEntity:
                                            f' sheet contains an invalid value (value: {int_value}).')
 
         if 'ints' in self.fields:
-            for int_value in [t for t in self.fields['ints'] if t in entity and not isinstance(t, int)]:
+            for int_value in [t for t in self.fields['ints'] if t in entity and not isinstance(entity[t], int)]:
                 try:
                     entity[int_value] = int(entity[int_value])
                 except ValueError:

--- a/uploader/entities/entity.py
+++ b/uploader/entities/entity.py
@@ -91,7 +91,7 @@ class CofkEntity:
                 elif isinstance(entity[id_field], str):
                     for int_value in [i for i in entity[id_field].split(SEPARATOR) if i != '']:
                         try:
-                            if int(int_value) < 0:
+                            if int(int_value) < 1:
                                 self.add_error(f'Column {id_field} in {self.sheet.name}'
                                                f' sheet contains an invalid value (value: {int_value}).')
                         except ValueError:

--- a/uploader/entities/locations.py
+++ b/uploader/entities/locations.py
@@ -5,6 +5,7 @@ from typing import List, Generator, Tuple
 from openpyxl.cell import Cell
 
 from location.models import CofkUnionLocation
+from uploader.constants import BULK_LOCATIONS_SHEET
 from uploader.entities.entity import CofkEntity
 from uploader.models import CofkCollectUpload, CofkCollectLocation
 
@@ -62,3 +63,76 @@ class CofkLocations(CofkEntity, ABC):
     def location_exists_by_name(self, name: str) -> bool:
         loc = [p for p in self.locations if p.location_name and p.location_name.lower() == name.lower() and p.union_location is None]
         return len(loc) > 0
+
+
+class CofkBulkLocations(CofkEntity, ABC):
+    """
+    Processes the bulk Places spreadsheet (BULKnewLOCATIONrecordsTEMPLATE format).
+
+    All records are treated as new locations — no IDs referencing the Union catalogue.
+    Columns are mapped by position using BULK_LOCATIONS_SHEET.
+    The location_name is constructed from the individual place-name component fields.
+    """
+
+    @property
+    def fields(self) -> dict:
+        return BULK_LOCATIONS_SHEET
+
+    def __init__(self, upload: CofkCollectUpload, sheet):
+        super().__init__(upload, sheet)
+        self.locations: List[CofkCollectLocation] = []
+        location_ids = list(CofkCollectLocation.objects.values_list('location_id').order_by('-location_id')[:1])
+        latest_location_id = location_ids[0][0] if len(location_ids) == 1 else 0
+
+        for index, row in enumerate(self.sheet.worksheet.iter_rows(), start=1):
+            row_dict = self.get_row(row, index)
+
+            if index <= self.sheet.header_length or row_dict == {}:
+                continue
+
+            self.check_required(row_dict)
+            self.check_data_types(row_dict)
+
+            location_name = self._build_location_name(row_dict)
+
+            if not location_name:
+                self.add_error('Row contains no location data; at least one place name field is required.')
+                continue
+
+            if self.location_exists_by_name(location_name):
+                log.warning(f'Duplicate location "{location_name}" in bulk Places sheet, skipping.')
+                continue
+
+            latest_location_id += 1
+            loc_kwargs = {
+                'location_id': latest_location_id,
+                'upload': upload,
+                'location_name': location_name,
+            }
+
+            for field in ['element_1_eg_room', 'element_2_eg_building', 'element_3_eg_parish',
+                          'element_4_eg_city', 'element_5_eg_county', 'element_6_eg_country',
+                          'element_7_eg_empire', 'location_synonyms', 'notes_on_place', 'editors_notes']:
+                if field in row_dict:
+                    loc_kwargs[field] = row_dict[field]
+
+            # latitude and longitude are stored as CharField but come from Excel as floats
+            for field in ['latitude', 'longitude']:
+                if field in row_dict:
+                    loc_kwargs[field] = str(row_dict[field])
+
+            self.locations.append(CofkCollectLocation(**loc_kwargs))
+
+    def _build_location_name(self, row_dict: dict) -> str:
+        """Build a display name from whichever place component fields are present."""
+        ordered_fields = ['element_4_eg_city', 'element_5_eg_county', 'element_6_eg_country',
+                          'element_3_eg_parish', 'element_2_eg_building',
+                          'element_1_eg_room', 'element_7_eg_empire']
+        parts = [str(row_dict[f]) for f in ordered_fields if f in row_dict and row_dict[f] is not None]
+        return ', '.join(parts)
+
+    def location_exists_by_name(self, name: str) -> bool:
+        return any(
+            loc.location_name and loc.location_name.lower() == name.lower()
+            for loc in self.locations
+        )

--- a/uploader/entities/people.py
+++ b/uploader/entities/people.py
@@ -3,6 +3,7 @@ from abc import ABC
 from typing import List
 
 from person.models import CofkUnionPerson
+from uploader.constants import BULK_PEOPLE_SHEET
 from uploader.entities.entity import CofkEntity
 from uploader.models import CofkCollectUpload, CofkCollectPerson
 
@@ -77,3 +78,61 @@ class CofkPeople(CofkEntity, ABC):
 
     def person_exists_by_name(self, name: str) -> bool:
         return len([p for p in self.people if p.primary_name and p.primary_name.lower() == name.lower() and p.union_iperson is None]) > 0
+
+
+class CofkBulkPeople(CofkEntity, ABC):
+    """
+    Processes the bulk People spreadsheet (BULKnewPEOPLErecordsTEMPLATE format).
+
+    All records are treated as new people — no IDs referencing the Union catalogue.
+    Columns are mapped by position using BULK_PEOPLE_SHEET.
+    """
+
+    @property
+    def fields(self) -> dict:
+        return BULK_PEOPLE_SHEET
+
+    def __init__(self, upload: CofkCollectUpload, sheet):
+        super().__init__(upload, sheet)
+        self.people: List[CofkCollectPerson] = []
+        iperson_ids = list(CofkCollectPerson.objects.values_list('iperson_id').order_by('-iperson_id')[:1])
+        latest_iperson_id = iperson_ids[0][0] if len(iperson_ids) == 1 else 0
+
+        for index, row in enumerate(self.sheet.worksheet.iter_rows(), start=1):
+            row_dict = self.get_row(row, index)
+
+            if index <= self.sheet.header_length or row_dict == {}:
+                continue
+
+            self.check_required(row_dict)
+            self.check_data_types(row_dict)
+
+            if 'primary_name' not in row_dict:
+                continue
+
+            primary_name = row_dict['primary_name']
+
+            if self.person_exists_by_name(primary_name):
+                log.warning(f'Duplicate person name "{primary_name}" in bulk People sheet, skipping.')
+                continue
+
+            latest_iperson_id += 1
+            person_kwargs = {
+                'iperson_id': latest_iperson_id,
+                'upload': upload,
+                'primary_name': primary_name,
+            }
+
+            for field in ['alternative_names', 'roles_or_titles', 'gender', 'is_organisation',
+                          'date_of_birth_year', 'date_of_birth_inferred', 'date_of_birth_uncertain',
+                          'date_of_birth_approx', 'date_of_death_year', 'date_of_death_inferred',
+                          'date_of_death_uncertain', 'date_of_death_approx',
+                          'flourished_year', 'flourished2_year', 'flourished_is_range',
+                          'notes_on_person', 'editors_notes']:
+                if field in row_dict:
+                    person_kwargs[field] = row_dict[field]
+
+            self.people.append(CofkCollectPerson(**person_kwargs))
+
+    def person_exists_by_name(self, name: str) -> bool:
+        return any(p.primary_name and p.primary_name.lower() == name.lower() for p in self.people)

--- a/uploader/entities/work.py
+++ b/uploader/entities/work.py
@@ -97,6 +97,8 @@ class CofkWork(CofkEntity):
 
     def get_person(self, person_id: str, person_name: str = None) -> CofkCollectPerson:
         if person_id is None or person_id == '':
+            if person_name is None:
+                return None
             people = [p for p in self.people if p.primary_name and p.primary_name.lower() == person_name.lower()]
 
             if len(people) == 1:
@@ -151,9 +153,9 @@ class CofkWork(CofkEntity):
 
     def process_locations(self, work: CofkCollectWork, location_list: List[Any], location_model: Type[models.Model],
                           work_dict: dict, ids: str, names: str, id_type: str):
-        for work_dict in self.clean_lists(work_dict, ids, names):
-            _id = work_dict[ids]
-            name = work_dict[names]
+        for location_entry in self.clean_lists(work_dict, ids, names):
+            _id = location_entry[ids]
+            name = location_entry[names]
             if location := self.get_location(_id, name):
                 related_location = location_model(upload=self.upload, iwork=work, location=location)
                 setattr(related_location, id_type, self.get_new_id(id_type))

--- a/uploader/migrations/0009_cofkcollectupload_upload_type.py
+++ b/uploader/migrations/0009_cofkcollectupload_upload_type.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('uploader', '0008_alter_cofkcollectupload_upload_file'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cofkcollectupload',
+            name='upload_type',
+            field=models.CharField(default='work', max_length=20),
+        ),
+    ]

--- a/uploader/models.py
+++ b/uploader/models.py
@@ -51,6 +51,7 @@ class CofkCollectUpload(models.Model):
     _id = models.CharField(max_length=32, blank=True, null=True)
     upload_name = models.CharField(max_length=254, blank=True, null=True)
     upload_file = models.FileField(upload_to=user_directory_path, blank=True, null=True)  # schema changed
+    upload_type = models.CharField(max_length=20, default='work')  # 'work' | 'people' | 'location'
 
     class Meta:
         db_table = 'cofk_collect_upload'

--- a/uploader/review.py
+++ b/uploader/review.py
@@ -290,6 +290,10 @@ def create_works(collect_works, username, union_work_dict, upload, request):
                 inst = manif.repository
                 union_inst = CofkUnionInstitution.objects.filter(pk=inst.institution_id).first()
 
+                if union_inst is None:
+                    log.warning(f'No union institution found for repository id {inst.institution_id}, skipping.')
+                    continue
+
                 cmim = CofkManifInstMap(relationship_type=REL_TYPE_STORED_IN,
                                         manif=union_manif, inst=union_inst, inst_id=union_inst.institution_id)
                 cmim.update_current_user_timestamp(username)

--- a/uploader/review.py
+++ b/uploader/review.py
@@ -373,6 +373,99 @@ def create_works(collect_works, username, union_work_dict, upload, request):
     log.info(f'{upload}: created ' + ', '.join(log_msg))
 
 
+def accept_people(upload: CofkCollectUpload, username: str, request=None):
+    """Accept a bulk people upload — create CofkUnionPerson for all new collect people."""
+    collect_people = CofkCollectPerson.objects.filter(upload=upload, union_iperson__isnull=True)
+
+    if not collect_people.exists():
+        msg = f'No new people in the upload "{upload.upload_name}" to accept.'
+        if request:
+            messages.warning(request, msg)
+        return
+
+    try:
+        with transaction.atomic():
+            for person in collect_people:
+                union_person = CofkUnionPerson(foaf_name=person.primary_name)
+                union_person.person_id = create_person_id(union_person.iperson_id)
+                union_person.update_current_user_timestamp(username)
+                union_person.save()
+                person.union_iperson = union_person
+                person.save()
+                log.info(f'Created new union person {union_person}')
+
+            upload.upload_status_id = 4  # Accepted and saved into main database
+            upload.save()
+
+    except Exception as e:
+        log.error(f'Bulk people upload {upload} failed.')
+        log.exception(e)
+        if request:
+            messages.error(request, 'An error occurred while accepting people. Please try again.')
+        return
+
+    msg = f'Successfully accepted {collect_people.count()} new people.'
+    if request:
+        messages.success(request, msg)
+    log.info(f'{upload}: {msg}')
+
+
+def reject_people(upload: CofkCollectUpload, request=None):
+    """Reject a bulk people upload."""
+    upload.upload_status_id = 3  # Review complete
+    upload.save()
+    msg = f'Upload "{upload.upload_name}" has been rejected.'
+    if request:
+        messages.success(request, msg)
+    log.info(f'{upload}: rejected (people bulk upload)')
+
+
+def accept_locations(upload: CofkCollectUpload, username: str, request=None):
+    """Accept a bulk locations upload — create CofkUnionLocation for all new collect locations."""
+    collect_locations = CofkCollectLocation.objects.filter(upload=upload, union_location__isnull=True)
+
+    if not collect_locations.exists():
+        msg = f'No new locations in the upload "{upload.upload_name}" to accept.'
+        if request:
+            messages.warning(request, msg)
+        return
+
+    try:
+        with transaction.atomic():
+            for location in collect_locations:
+                union_location = CofkUnionLocation(location_name=location.location_name)
+                union_location.update_current_user_timestamp(username)
+                union_location.save()
+                location.union_location = union_location
+                location.save()
+                log.info(f'Created new union location {union_location}')
+
+            upload.upload_status_id = 4  # Accepted and saved into main database
+            upload.save()
+
+    except Exception as e:
+        log.error(f'Bulk locations upload {upload} failed.')
+        log.exception(e)
+        if request:
+            messages.error(request, 'An error occurred while accepting locations. Please try again.')
+        return
+
+    msg = f'Successfully accepted {collect_locations.count()} new locations.'
+    if request:
+        messages.success(request, msg)
+    log.info(f'{upload}: {msg}')
+
+
+def reject_locations(upload: CofkCollectUpload, request=None):
+    """Reject a bulk locations upload."""
+    upload.upload_status_id = 3  # Review complete
+    upload.save()
+    msg = f'Upload "{upload.upload_name}" has been rejected.'
+    if request:
+        messages.success(request, msg)
+    log.info(f'{upload}: rejected (locations bulk upload)')
+
+
 def reject_works(context: dict, upload: CofkCollectUpload, request):
     filter_args = {'upload_status_id': 1}
 

--- a/uploader/review.py
+++ b/uploader/review.py
@@ -386,7 +386,33 @@ def accept_people(upload: CofkCollectUpload, username: str, request=None):
     try:
         with transaction.atomic():
             for person in collect_people:
-                union_person = CofkUnionPerson(foaf_name=person.primary_name)
+                union_person = CofkUnionPerson(
+                    init_seq_id=True,
+                    foaf_name=person.primary_name,
+                    gender=person.gender,
+                    is_organisation=person.is_organisation,
+                    editors_notes=person.editors_notes,
+                    date_of_birth_year=person.date_of_birth_year,
+                    date_of_birth_month=person.date_of_birth_month,
+                    date_of_birth_day=person.date_of_birth_day,
+                    date_of_birth_inferred=person.date_of_birth_inferred,
+                    date_of_birth_uncertain=person.date_of_birth_uncertain,
+                    date_of_birth_approx=person.date_of_birth_approx,
+                    date_of_birth_is_range=person.date_of_birth_is_range,
+                    date_of_birth2_year=person.date_of_birth2_year,
+                    date_of_birth2_month=person.date_of_birth2_month,
+                    date_of_birth2_day=person.date_of_birth2_day,
+                    date_of_death_year=person.date_of_death_year,
+                    date_of_death_month=person.date_of_death_month,
+                    date_of_death_day=person.date_of_death_day,
+                    date_of_death_inferred=person.date_of_death_inferred,
+                    date_of_death_uncertain=person.date_of_death_uncertain,
+                    date_of_death_approx=person.date_of_death_approx,
+                    date_of_death_is_range=person.date_of_death_is_range,
+                    date_of_death2_year=person.date_of_death2_year,
+                    date_of_death2_month=person.date_of_death2_month,
+                    date_of_death2_day=person.date_of_death2_day,
+                )
                 union_person.person_id = create_person_id(union_person.iperson_id)
                 union_person.update_current_user_timestamp(username)
                 union_person.save()
@@ -433,7 +459,20 @@ def accept_locations(upload: CofkCollectUpload, username: str, request=None):
     try:
         with transaction.atomic():
             for location in collect_locations:
-                union_location = CofkUnionLocation(location_name=location.location_name)
+                union_location = CofkUnionLocation(
+                    location_name=location.location_name,
+                    element_1_eg_room=location.element_1_eg_room,
+                    element_2_eg_building=location.element_2_eg_building,
+                    element_3_eg_parish=location.element_3_eg_parish,
+                    element_4_eg_city=location.element_4_eg_city,
+                    element_5_eg_county=location.element_5_eg_county,
+                    element_6_eg_country=location.element_6_eg_country,
+                    element_7_eg_empire=location.element_7_eg_empire,
+                    location_synonyms=location.location_synonyms,
+                    editors_notes=location.editors_notes,
+                    latitude=location.latitude,
+                    longitude=location.longitude,
+                )
                 union_location.update_current_user_timestamp(username)
                 union_location.save()
                 location.union_location = union_location

--- a/uploader/spreadsheet.py
+++ b/uploader/spreadsheet.py
@@ -56,59 +56,80 @@ class CofkUploadExcelFile:
 
         self.wb = load_workbook(filename=filename, data_only=True, read_only=True)
 
-        # Make sure all sheets are present
-        self.check_sheets()
+        self.upload_type = self.check_sheets()
 
+        if self.upload_type == 'work':
+            self._process_work_upload()
+        elif self.upload_type == 'people':
+            self._process_people_only()
+        elif self.upload_type == 'location':
+            self._process_locations_only()
+
+    def check_sheets(self) -> str:
+        """Determine upload type from sheets present. Returns 'work', 'people', or 'location'."""
+        present = set(self.wb.sheetnames)
+
+        if 'Work' in present or 'Manifestation' in present:
+            missing = set(MANDATORY_SHEETS.keys()) - present
+            if missing:
+                msg = f'Missing sheets: {", ".join(sorted(missing))}'
+                log.error(msg)
+                raise CofkExcelFileError(msg)
+            return 'work'
+        elif 'People' in present and 'Places' not in present:
+            return 'people'
+        elif 'Places' in present and 'People' not in present:
+            return 'location'
+        else:
+            msg = ('Could not determine upload type. File must contain either a Work sheet '
+                   '(standard upload), only a People sheet (bulk people), or only a Places sheet '
+                   '(bulk locations).')
+            log.error(msg)
+            raise CofkExcelFileError(msg)
+
+    def _load_sheet(self, sheet_name: str):
+        """Load and validate a single sheet, appending to self.missing on error."""
+        try:
+            self.sheets[sheet_name] = CofkSheet(self.wb[sheet_name])
+        except StopIteration:
+            self.missing.append(f'{sheet_name} is missing its header rows.')
+            return
+
+        if self.sheets[sheet_name].missing_columns:
+            cols = self.sheets[sheet_name].missing_columns
+            ms = ('columns ' + ', '.join(cols)) if len(cols) > 1 else f'column "{cols.pop()}"'
+            self.missing.append(f'Missing {ms} from the sheet {sheet_name}.')
+
+    def _process_work_upload(self):
+        """Process a standard 5-sheet work upload."""
         for sheet in MANDATORY_SHEETS.keys():
-            try:
-                self.sheets[sheet] = CofkSheet(self.wb[sheet])
-            except StopIteration:
-                self.missing.append(f'{sheet} is missing its header rows.')
-                # raise CofkExcelFileError(f'{sheet} is missing its header rows.')
-
-            # Using same iteration to verify that required columns are present
-            if sheet in self.sheets and self.sheets[sheet].missing_columns:
-                if len(self.sheets[sheet].missing_columns) > 1:
-                    ms = 'columns ' + ', '.join(self.sheets[sheet].missing_columns)
-
-                else:
-                    ms = f'column "{self.sheets[sheet].missing_columns.pop()}"'
-                self.missing.append(f'Missing {ms} from the sheet {sheet}.')
+            self._load_sheet(sheet)
 
         if self.missing:
             raise CofkExcelFileError('</br> '.join(self.missing))
 
-        # Quick check that works are present in upload, no need to go further if not
-        # sheets have already been verified to be present so no KeyError raised
         if self.sheets['Work'].rows == 0:
             raise CofkExcelFileError("Spreadsheet contains no works.")
 
-        sheets = ', '.join([f'{sheet}: {self.sheets[sheet].rows} ({self.sheets[sheet].worksheet.calculate_dimension()})' for sheet in MANDATORY_SHEETS.keys()])
+        sheets = ', '.join([
+            f'{s}: {self.sheets[s].rows} ({self.sheets[s].worksheet.calculate_dimension()})'
+            for s in MANDATORY_SHEETS.keys()
+        ])
         log.info(f'{self.upload}: all {len(MANDATORY_SHEETS)} sheets verified: [{sheets}]')
-        # log.info(f'About to process {self.wb.sheet[sheet]}')
 
-        # It's process the sheets in reverse order, starting with repositories/institutions
         self.sheets['Repositories'].entities = CofkRepositories(upload=self.upload,
                                                                 sheet=self.sheets['Repositories'])
-
-        # The next sheet is places/locations,
         self.sheets['Places'].entities = CofkLocations(upload=self.upload, sheet=self.sheets['Places'],
                                                        work_data=self.sheets['Work'].worksheet)
-
-        # The next sheet is people
         self.sheets['People'].entities = CofkPeople(upload=self.upload, sheet=self.sheets['People'])
-
-        # Second last but not least, the works themselves
         self.sheets['Work'].entities = CofkWork(upload=self.upload, sheet=self.sheets['Work'],
                                                 people=self.sheets['People'].entities.people,
                                                 locations=self.sheets['Places'].entities.locations)
-
-        # The last sheet is manifestations
-        self.sheets['Manifestation'].entities = CofkManifestations(upload=self.upload,
-                                                                   sheet=self.sheets['Manifestation'],
-                                                                   repositories=self.sheets[
-                                                                       'Repositories'].entities.institutions,
-                                                                   works=self.sheets['Work'].entities.works)
+        self.sheets['Manifestation'].entities = CofkManifestations(
+            upload=self.upload,
+            sheet=self.sheets['Manifestation'],
+            repositories=self.sheets['Repositories'].entities.institutions,
+            works=self.sheets['Work'].entities.works)
 
         if self.sheets['People'].entities.other_errors:
             for row_index in self.sheets['People'].entities.other_errors:
@@ -119,24 +140,19 @@ class CofkUploadExcelFile:
         if self.sheets['Work'].entities.errors:
             self.errors['work'] = self.sheets['Work'].entities.format_errors_for_template()
             self.total_errors += self.errors['work']['total']
-
         if self.sheets['People'].entities.errors:
             self.errors['people'] = self.sheets['People'].entities.format_errors_for_template()
             self.total_errors += self.errors['people']['total']
-
         if self.sheets['Repositories'].entities.errors:
             self.errors['repositories'] = self.sheets['Repositories'].entities.format_errors_for_template()
             self.total_errors += self.errors['repositories']['total']
-
         if self.sheets['Places'].entities.errors:
             self.errors['locations'] = self.sheets['Places'].entities.format_errors_for_template()
             self.total_errors += self.errors['locations']['total']
-
         if self.sheets['Manifestation'].entities and self.sheets['Manifestation'].entities.errors:
             self.errors['manifestations'] = self.sheets['Manifestation'].entities.format_errors_for_template()
             self.total_errors += self.errors['manifestations']['total']
 
-        # Create all collect objects if there are no errors
         if self.total_errors == 0:
             people = self.sheets['People'].entities.people
             self.sheets['People'].entities.bulk_create(people)
@@ -156,18 +172,44 @@ class CofkUploadExcelFile:
             self.sheets['Manifestation'].entities.bulk_create(manifs)
             self.sheets['Manifestation'].entities.log_summary.append(f'{len(manifs)} CofkCollectManifestation')
 
-            log_msg = self.sheets['Work'].entities.log_summary + self.sheets['Manifestation'].entities.log_summary \
-                      + self.sheets['Repositories'].entities.log_summary
+            log_msg = (self.sheets['Work'].entities.log_summary
+                       + self.sheets['Manifestation'].entities.log_summary
+                       + self.sheets['Repositories'].entities.log_summary)
             log.info(f'{self.upload}: created ' + ', '.join(log_msg))
 
-    def check_sheets(self):
-        # Verify all required sheets are present
-        difference = list(set(MANDATORY_SHEETS.keys()) - set([n for n in self.wb.sheetnames]))
+    def _process_people_only(self):
+        """Process a bulk people-only upload."""
+        self._load_sheet('People')
 
-        if difference:
-            if len(difference) == 1:
-                msg = f'Missing sheet: {difference[0].title()}'
-            else:
-                msg = f'Missing sheets: {", ".join(sorted([n.title() for n in difference]))}'
-            log.error(msg)
-            raise CofkExcelFileError(msg)
+        if self.missing:
+            raise CofkExcelFileError('</br> '.join(self.missing))
+
+        self.sheets['People'].entities = CofkPeople(upload=self.upload, sheet=self.sheets['People'])
+
+        if self.sheets['People'].entities.errors:
+            self.errors['people'] = self.sheets['People'].entities.format_errors_for_template()
+            self.total_errors += self.errors['people']['total']
+
+        if self.total_errors == 0:
+            people = self.sheets['People'].entities.people
+            self.sheets['People'].entities.bulk_create(people)
+            log.info(f'{self.upload}: created {len(people)} CofkCollectPerson (bulk people upload)')
+
+    def _process_locations_only(self):
+        """Process a bulk locations-only upload."""
+        self._load_sheet('Places')
+
+        if self.missing:
+            raise CofkExcelFileError('</br> '.join(self.missing))
+
+        self.sheets['Places'].entities = CofkLocations(upload=self.upload, sheet=self.sheets['Places'],
+                                                       work_data=None)
+
+        if self.sheets['Places'].entities.errors:
+            self.errors['locations'] = self.sheets['Places'].entities.format_errors_for_template()
+            self.total_errors += self.errors['locations']['total']
+
+        if self.total_errors == 0:
+            locations = self.sheets['Places'].entities.locations
+            self.sheets['Places'].entities.bulk_create(locations)
+            log.info(f'{self.upload}: created {len(locations)} CofkCollectLocation (bulk locations upload)')

--- a/uploader/spreadsheet.py
+++ b/uploader/spreadsheet.py
@@ -7,9 +7,9 @@ from openpyxl.worksheet.worksheet import Worksheet
 
 from uploader.constants import MANDATORY_SHEETS
 from uploader.entities.entity import CofkEntity
-from uploader.entities.locations import CofkLocations
+from uploader.entities.locations import CofkLocations, CofkBulkLocations
 from uploader.entities.manifestations import CofkManifestations
-from uploader.entities.people import CofkPeople
+from uploader.entities.people import CofkPeople, CofkBulkPeople
 from uploader.entities.repositories import CofkRepositories
 from uploader.entities.work import CofkWork
 from uploader.models import CofkCollectUpload
@@ -178,13 +178,27 @@ class CofkUploadExcelFile:
             log.info(f'{self.upload}: created ' + ', '.join(log_msg))
 
     def _process_people_only(self):
-        """Process a bulk people-only upload."""
-        self._load_sheet('People')
+        """Process a people-only upload.
 
-        if self.missing:
-            raise CofkExcelFileError('</br> '.join(self.missing))
+        Detects format automatically:
+        - Standard (3-column) format: header row contains 'primary_name'
+        - Bulk (24-column) format: header row contains verbose column titles
+        """
+        try:
+            sheet = CofkSheet(self.wb['People'])
+        except StopIteration:
+            raise CofkExcelFileError('People sheet is missing its header rows.')
 
-        self.sheets['People'].entities = CofkPeople(upload=self.upload, sheet=self.sheets['People'])
+        is_bulk = 'primary_name' not in sheet.header
+
+        if not is_bulk and sheet.missing_columns:
+            cols = sheet.missing_columns
+            ms = ('columns ' + ', '.join(cols)) if len(cols) > 1 else f'column "{cols.pop()}"'
+            raise CofkExcelFileError(f'Missing {ms} from the People sheet.')
+
+        self.sheets['People'] = sheet
+        entity_class = CofkBulkPeople if is_bulk else CofkPeople
+        self.sheets['People'].entities = entity_class(upload=self.upload, sheet=self.sheets['People'])
 
         if self.sheets['People'].entities.errors:
             self.errors['people'] = self.sheets['People'].entities.format_errors_for_template()
@@ -193,17 +207,37 @@ class CofkUploadExcelFile:
         if self.total_errors == 0:
             people = self.sheets['People'].entities.people
             self.sheets['People'].entities.bulk_create(people)
-            log.info(f'{self.upload}: created {len(people)} CofkCollectPerson (bulk people upload)')
+            fmt = 'bulk people' if is_bulk else 'people'
+            log.info(f'{self.upload}: created {len(people)} CofkCollectPerson ({fmt} upload)')
 
     def _process_locations_only(self):
-        """Process a bulk locations-only upload."""
-        self._load_sheet('Places')
+        """Process a locations-only upload.
 
-        if self.missing:
-            raise CofkExcelFileError('</br> '.join(self.missing))
+        Detects format automatically:
+        - Standard (2-column) format: header row contains 'location_name'
+        - Bulk (14-column) format: header row contains verbose column titles
+        """
+        try:
+            sheet = CofkSheet(self.wb['Places'])
+        except StopIteration:
+            raise CofkExcelFileError('Places sheet is missing its header rows.')
 
-        self.sheets['Places'].entities = CofkLocations(upload=self.upload, sheet=self.sheets['Places'],
-                                                       work_data=None)
+        is_bulk = 'location_name' not in sheet.header
+
+        if not is_bulk and sheet.missing_columns:
+            cols = sheet.missing_columns
+            ms = ('columns ' + ', '.join(cols)) if len(cols) > 1 else f'column "{cols.pop()}"'
+            raise CofkExcelFileError(f'Missing {ms} from the Places sheet.')
+
+        self.sheets['Places'] = sheet
+
+        if is_bulk:
+            self.sheets['Places'].entities = CofkBulkLocations(upload=self.upload,
+                                                               sheet=self.sheets['Places'])
+        else:
+            self.sheets['Places'].entities = CofkLocations(upload=self.upload,
+                                                           sheet=self.sheets['Places'],
+                                                           work_data=None)
 
         if self.sheets['Places'].entities.errors:
             self.errors['locations'] = self.sheets['Places'].entities.format_errors_for_template()
@@ -212,4 +246,5 @@ class CofkUploadExcelFile:
         if self.total_errors == 0:
             locations = self.sheets['Places'].entities.locations
             self.sheets['Places'].entities.bulk_create(locations)
-            log.info(f'{self.upload}: created {len(locations)} CofkCollectLocation (bulk locations upload)')
+            fmt = 'bulk locations' if is_bulk else 'locations'
+            log.info(f'{self.upload}: created {len(locations)} CofkCollectLocation ({fmt} upload)')

--- a/uploader/templates/uploader/list.html
+++ b/uploader/templates/uploader/list.html
@@ -5,18 +5,19 @@
 
 <h1>Uploads</h1>
 
-<div style="text-align: right;">
+{% include "core/component/messages.html" %}
+
+<div class="right">
     <h2>{{ page_obj|get_results_on_page }} out
         of {{ paginator.count | floatformat:'g' }} uploads</h2>
 </div>
-
-{% include "core/component/messages.html" %}
 
 {% include 'core/component/pagination.html' %}
 
 <table>
     <tr>
         <th>ID</th>
+        <th>Type</th>
         <th>Date/time</th>
         <th>Source of data</th>
         <th>Contact email</th>
@@ -29,8 +30,8 @@
     </tr>
 {% for upload in object_list %}
     <tr>
-
         <td>{{ upload.upload_id }}</td>
+        <td>{{ upload.upload_type }}</td>
         <td>{{ upload.upload_timestamp|standard_datetime }}</td>
         <td>{{ upload.upload_name }}</td>
         <td>{{ upload.uploader_email }}</td>
@@ -40,7 +41,6 @@
         <td>{{ upload.upload_status }}</td>
         <td><form action="/upload/{{ upload.upload_id }}"><button type="submit" class="btn">Review</button></form></td>
         <!--<td><input type="button" value="Export"></td>-->
-
     </tr>
 {% endfor %}
 </table>

--- a/uploader/templates/uploader/list.html
+++ b/uploader/templates/uploader/list.html
@@ -35,9 +35,24 @@
         <td>{{ upload.upload_timestamp|standard_datetime }}</td>
         <td>{{ upload.upload_name }}</td>
         <td>{{ upload.uploader_email }}</td>
-        <td>{{ upload.total_works }}</td>
-        <td>{{ upload.works_accepted }}</td>
-        <td>{{ upload.works_rejected }}</td>
+        <td>
+            {% if upload.upload_type == 'work' %}
+            {{ upload.total_works }}
+            {% else %}
+            N/A
+            {% endif %}</td>
+        <td>
+            {% if upload.upload_type == 'work' %}
+            {{ upload.works_accepted }}
+            {% else %}
+            N/A
+            {% endif %}</td>
+        <td>
+            {% if upload.upload_type == 'work' %}
+            {{ upload.works_rejected }}
+            {% else %}
+            N/A
+            {% endif %}</td>
         <td>{{ upload.upload_status }}</td>
         <td><form action="/upload/{{ upload.upload_id }}"><button type="submit" class="btn">Review</button></form></td>
         <!--<td><input type="button" value="Export"></td>-->

--- a/uploader/templates/uploader/review.html
+++ b/uploader/templates/uploader/review.html
@@ -4,7 +4,7 @@
 {% block content %}
 
 <div id="upload-header">
-    <h3>Contribution by {{ upload.upload_username }} uploaded {{ upload.upload_timestamp }}</h3>
+    <span id="upload-title">Contribution by {{ upload.upload_username }} uploaded {{ upload.upload_timestamp }}</span>
 
     <span id="upload-summary">Status: {{ upload.upload_status }} | Number of works uploaded: {{ upload.total_works }} | Accepted: {{ upload.works_accepted}} | Rejected: {{ upload.works_rejected}}</span>
 

--- a/uploader/templates/uploader/review_locations.html
+++ b/uploader/templates/uploader/review_locations.html
@@ -1,0 +1,59 @@
+{% extends "core/emlo_logined.html" %}
+{% load static %}
+
+{% block content %}
+
+<div id="upload-header">
+    <span id="upload-title">Bulk locations upload by {{ upload.upload_username }} uploaded {{ upload.upload_timestamp }}</span>
+    <span id="upload-summary">Status: {{ upload.upload_status }} | Locations in upload: {{ locations.count }}</span>
+
+    <div class="padding-top">
+        Back to list of contributions
+        <button type="button" class="btn inline_btn" onclick="location.href='/upload'">Back</button>
+
+        <button class="btn inline_btn" id="accept_all" onclick="document.getElementById('confirm').style.display='block'; document.getElementById('action').value='accept';">Accept all</button>
+        <button class="btn inline_btn" id="reject_all" onclick="document.getElementById('confirm').style.display='block'; document.getElementById('action').value='reject';">Reject all</button>
+    </div>
+    <em>Note: confirmation will be required before Accept/Reject.</em>
+</div>
+
+{% include "core/component/messages.html" %}
+
+<form method="post">
+    {% csrf_token %}
+    <fieldset id="confirm" style="max-width: 50%; margin-top: 1em; display: none;">
+        <h2 id="confirm_title">Accept {{ locations.count }} new locations?</h2>
+        <p>This will create new entries in the union catalogue for each new location listed below.</p>
+        <input type="hidden" value="" name="action" id="action"/>
+        <button class="btn inline_btn" name="confirm">Confirm</button>
+        <button type="button" class="btn inline_btn" onclick="document.getElementById('confirm').style.display='none';">Cancel</button>
+    </fieldset>
+</form>
+
+<div id="review">
+    <h2>Locations ({{ locations.count }})</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Location name</th>
+                <th>Editors' notes</th>
+                <th>Union record</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for location in locations %}
+            <tr>
+                <td>{{ location.location_id }}</td>
+                <td>{{ location.location_name }}</td>
+                <td>{{ location.editors_notes|default:'' }}</td>
+                <td>{% if location.union_location %}Linked to union record {{ location.union_location.location_id }}{% else %}New{% endif %}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="4">No locations in this upload.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% endblock %}

--- a/uploader/templates/uploader/review_people.html
+++ b/uploader/templates/uploader/review_people.html
@@ -1,0 +1,59 @@
+{% extends "core/emlo_logined.html" %}
+{% load static %}
+
+{% block content %}
+
+<div id="upload-header">
+    <span id="upload-title">Bulk people upload by {{ upload.upload_username }} uploaded {{ upload.upload_timestamp }}</span>
+    <span id="upload-summary">Status: {{ upload.upload_status }} | People in upload: {{ people.count }}</span>
+
+    <div class="padding-top">
+        Back to list of contributions
+        <button type="button" class="btn inline_btn" onclick="location.href='/upload'">Back</button>
+
+        <button class="btn inline_btn" id="accept_all" onclick="document.getElementById('confirm').style.display='block'; document.getElementById('action').value='accept';">Accept all</button>
+        <button class="btn inline_btn" id="reject_all" onclick="document.getElementById('confirm').style.display='block'; document.getElementById('action').value='reject';">Reject all</button>
+    </div>
+    <em>Note: confirmation will be required before Accept/Reject.</em>
+</div>
+
+{% include "core/component/messages.html" %}
+
+<form method="post">
+    {% csrf_token %}
+    <fieldset id="confirm" style="max-width: 50%; margin-top: 1em; display: none;">
+        <h2 id="confirm_title">Accept {{ people.count }} new people?</h2>
+        <p>This will create new entries in the union catalogue for each new person listed below.</p>
+        <input type="hidden" value="" name="action" id="action"/>
+        <button class="btn inline_btn" name="confirm">Confirm</button>
+        <button type="button" class="btn inline_btn" onclick="document.getElementById('confirm').style.display='none';">Cancel</button>
+    </fieldset>
+</form>
+
+<div id="review">
+    <h2>People ({{ people.count }})</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Primary name</th>
+                <th>Editors' notes</th>
+                <th>Union record</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for person in people %}
+            <tr>
+                <td>{{ person.iperson_id }}</td>
+                <td>{{ person.primary_name }}</td>
+                <td>{{ person.editors_notes|default:'' }}</td>
+                <td>{% if person.union_iperson %}Linked to union record {{ person.union_iperson.iperson_id }}{% else %}New{% endif %}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="4">No people in this upload.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% endblock %}

--- a/uploader/test/test_bulk_locations.py
+++ b/uploader/test/test_bulk_locations.py
@@ -1,0 +1,183 @@
+import logging
+import tempfile
+
+from openpyxl.workbook import Workbook
+
+from uploader.models import CofkCollectLocation
+from uploader.spreadsheet import CofkUploadExcelFile
+from uploader.test.test_serv import UploadIncludedTestCase
+
+log = logging.getLogger(__name__)
+
+# Verbose column headers that trigger bulk detection (no 'location_name' in row 1)
+BULK_LOCATIONS_HEADERS = [
+    'Name of City/town/village', 'Name of County', 'Name of Country',
+    'Name of District of city', 'Name of Building', 'Name of Room', 'Name of Empire',
+    'Synonyms/Alternative names', 'LATITUDE', 'LONGITUDE',
+    'GENERAL NOTES ON PLACE', "EDITORS' NOTES AND QUERIES",
+    'RELATED RESOURCE NAME', 'RELATED RESOURCE URL',
+]
+
+
+class TestBulkLocations(UploadIncludedTestCase):
+
+    def create_bulk_locations_file(self, data_rows: list) -> str:
+        wb = Workbook()
+        ws = wb.create_sheet('Places')
+        ws.append(BULK_LOCATIONS_HEADERS)
+        ws.append(['-'] * len(BULK_LOCATIONS_HEADERS))
+        for row in data_rows:
+            ws.append(row)
+        tf = tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False)
+        wb.save(tf.name)
+        self.tmp_files.append(tf.name)
+        return tf.name
+
+    def _row(self, city=None, county=None, country=None, parish=None, building=None,
+             room=None, empire=None, synonyms=None, latitude=None, longitude=None,
+             notes=None, editors_notes=None, resource_name=None, resource_url=None):
+        return [city, county, country, parish, building, room, empire,
+                synonyms, latitude, longitude, notes, editors_notes,
+                resource_name, resource_url]
+
+    def test_bulk_locations_creates_records(self):
+        """Valid bulk locations upload creates a CofkCollectLocation record with correct fields."""
+        row = self._row(city='London', country='England', synonyms='Londinium',
+                        editors_notes='capital city')
+        filename = self.create_bulk_locations_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        self.assertEqual(CofkCollectLocation.objects.count(), 1)
+        loc = CofkCollectLocation.objects.first()
+        self.assertEqual(loc.element_4_eg_city, 'London')
+        self.assertEqual(loc.element_6_eg_country, 'England')
+        self.assertEqual(loc.location_synonyms, 'Londinium')
+        self.assertEqual(loc.editors_notes, 'capital city')
+
+    def test_bulk_locations_name_from_city_and_country(self):
+        """location_name is constructed by joining available place component fields."""
+        row = self._row(city='Oxford', country='England')
+        filename = self.create_bulk_locations_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        loc = CofkCollectLocation.objects.first()
+        self.assertEqual(loc.location_name, 'Oxford, England')
+
+    def test_bulk_locations_name_from_all_components(self):
+        """location_name includes all provided component fields in order."""
+        row = self._row(city='Southwark', county='Surrey', country='England',
+                        parish='St George', building='The Bell Inn', room='Room 3',
+                        empire='British Empire')
+        filename = self.create_bulk_locations_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        loc = CofkCollectLocation.objects.first()
+        # Order: city, county, country, parish, building, room, empire
+        self.assertEqual(
+            loc.location_name,
+            'Southwark, Surrey, England, St George, The Bell Inn, Room 3, British Empire'
+        )
+
+    def test_bulk_locations_name_from_country_only(self):
+        """A single component field is sufficient to create a location."""
+        row = self._row(country='Scotland')
+        filename = self.create_bulk_locations_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        loc = CofkCollectLocation.objects.first()
+        self.assertEqual(loc.location_name, 'Scotland')
+
+    def test_bulk_locations_empty_row_error(self):
+        """A row with no place component fields generates a validation error and no record is created."""
+        row = self._row(synonyms='some alias', editors_notes='note')
+        filename = self.create_bulk_locations_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertIn('locations', cuef.errors)
+        self.assertEqual(CofkCollectLocation.objects.count(), 0)
+
+    def test_bulk_locations_duplicate_skipped(self):
+        """Two rows with the same constructed name result in only one record."""
+        rows = [
+            self._row(city='London', country='England'),
+            self._row(city='London', country='England'),
+        ]
+        filename = self.create_bulk_locations_file(rows)
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        self.assertEqual(CofkCollectLocation.objects.count(), 1)
+
+    def test_bulk_locations_multiple_records(self):
+        """Multiple rows create multiple CofkCollectLocation records."""
+        rows = [
+            self._row(city='London', country='England'),
+            self._row(city='Oxford', country='England'),
+            self._row(city='Cambridge', county='Cambridgeshire', country='England'),
+        ]
+        filename = self.create_bulk_locations_file(rows)
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        self.assertEqual(CofkCollectLocation.objects.count(), 3)
+
+    def test_bulk_locations_latlong_stored_as_string(self):
+        """Latitude and longitude provided as floats are stored as strings."""
+        row = self._row(city='London', latitude=51.5074, longitude=-0.1278)
+        filename = self.create_bulk_locations_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        loc = CofkCollectLocation.objects.first()
+        self.assertIsInstance(loc.latitude, str)
+        self.assertIsInstance(loc.longitude, str)
+
+    def test_bulk_locations_notes_stored(self):
+        """notes_on_place field is stored correctly."""
+        row = self._row(city='Rome', country='Italy', notes='Ancient city')
+        filename = self.create_bulk_locations_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        loc = CofkCollectLocation.objects.first()
+        self.assertEqual(loc.notes_on_place, 'Ancient city')
+
+    def test_bulk_locations_upload_type_detected(self):
+        """A Places-only bulk spreadsheet is detected as upload_type 'location'."""
+        filename = self.create_bulk_locations_file([self._row(city='London')])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.upload_type, 'location')
+
+    def test_bulk_locations_element_fields_stored(self):
+        """All individual place component fields are stored on the location record."""
+        row = self._row(city='Southwark', county='Surrey', country='England',
+                        parish='St Saviour', building='Winchester House',
+                        room='Great Hall', empire='British Empire')
+        filename = self.create_bulk_locations_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        loc = CofkCollectLocation.objects.first()
+        self.assertEqual(loc.element_4_eg_city, 'Southwark')
+        self.assertEqual(loc.element_5_eg_county, 'Surrey')
+        self.assertEqual(loc.element_6_eg_country, 'England')
+        self.assertEqual(loc.element_3_eg_parish, 'St Saviour')
+        self.assertEqual(loc.element_2_eg_building, 'Winchester House')
+        self.assertEqual(loc.element_1_eg_room, 'Great Hall')
+        self.assertEqual(loc.element_7_eg_empire, 'British Empire')

--- a/uploader/test/test_bulk_people.py
+++ b/uploader/test/test_bulk_people.py
@@ -1,0 +1,200 @@
+import logging
+import tempfile
+
+from openpyxl.workbook import Workbook
+
+from uploader.models import CofkCollectPerson
+from uploader.spreadsheet import CofkUploadExcelFile
+from uploader.test.test_serv import UploadIncludedTestCase
+from uploader.validation import CofkExcelFileError
+
+log = logging.getLogger(__name__)
+
+# Verbose column headers that trigger bulk detection (no 'primary_name' in row 1)
+BULK_PEOPLE_HEADERS = [
+    'Primary name', 'Synonyms', 'Occupations/roles/titles', 'GENDER', 'IS ORGANIZATION',
+    'BIRTH YEAR', 'BIRTH YEAR INFERRED', 'BIRTH YEAR UNCERTAIN', 'BIRTH YEAR APPROX',
+    'DEATH YEAR', 'DEATH YEAR INFERRED', 'DEATH YEAR UNCERTAIN', 'DEATH YEAR APPROX',
+    'FLOURISHED EARLIEST YEAR 1', 'FLOURISHED LATEST YEAR 2', 'FLOURISHED IS RANGE',
+    'FLOURISHED YEAR INFERRED', 'FLOURISHED YEAR UNCERTAIN', 'FLOURISHED YEAR APPROX',
+    'GENERAL NOTES ON PERSON', "EDITORS' NOTES AND QUERIES",
+    'RELATED RESOURCE NAME', 'RELATED RESOURCE URL', 'Further reading',
+]
+
+
+class TestBulkPeople(UploadIncludedTestCase):
+
+    def create_bulk_people_file(self, data_rows: list) -> str:
+        wb = Workbook()
+        ws = wb.create_sheet('People')
+        ws.append(BULK_PEOPLE_HEADERS)
+        ws.append(['-'] * len(BULK_PEOPLE_HEADERS))
+        for row in data_rows:
+            ws.append(row)
+        tf = tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False)
+        wb.save(tf.name)
+        self.tmp_files.append(tf.name)
+        return tf.name
+
+    def _row(self, primary_name=None, alternative_names=None, roles=None, gender=None,
+             is_org=None, birth_year=None, birth_inferred=None, birth_uncertain=None,
+             birth_approx=None, death_year=None, death_inferred=None, death_uncertain=None,
+             death_approx=None, fl_year=None, fl2_year=None, fl_range=None,
+             fl_inferred=None, fl_uncertain=None, fl_approx=None,
+             notes=None, editors_notes=None, resource_name=None, resource_url=None,
+             further_reading=None):
+        return [primary_name, alternative_names, roles, gender, is_org,
+                birth_year, birth_inferred, birth_uncertain, birth_approx,
+                death_year, death_inferred, death_uncertain, death_approx,
+                fl_year, fl2_year, fl_range, fl_inferred, fl_uncertain, fl_approx,
+                notes, editors_notes, resource_name, resource_url, further_reading]
+
+    def test_bulk_people_creates_records(self):
+        """Valid bulk people upload creates CofkCollectPerson records with correct field values."""
+        row = self._row(
+            primary_name='Isaac Newton',
+            gender='M',
+            birth_year=1643,
+            death_year=1727,
+            editors_notes='test notes',
+        )
+        filename = self.create_bulk_people_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        self.assertEqual(CofkCollectPerson.objects.count(), 1)
+        person = CofkCollectPerson.objects.first()
+        self.assertEqual(person.primary_name, 'Isaac Newton')
+        self.assertEqual(person.gender, 'M')
+        self.assertEqual(person.date_of_birth_year, 1643)
+        self.assertEqual(person.date_of_death_year, 1727)
+        self.assertEqual(person.editors_notes, 'test notes')
+
+    def test_bulk_people_multiple_records(self):
+        """Multiple rows create multiple CofkCollectPerson records."""
+        rows = [
+            self._row(primary_name='Isaac Newton', birth_year=1643),
+            self._row(primary_name='Robert Boyle', birth_year=1627),
+            self._row(primary_name='John Locke', death_year=1704),
+        ]
+        filename = self.create_bulk_people_file(rows)
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        self.assertEqual(CofkCollectPerson.objects.count(), 3)
+
+    def test_bulk_people_minimal(self):
+        """Only primary_name is required; upload succeeds with all other fields omitted."""
+        filename = self.create_bulk_people_file([self._row(primary_name='John Doe')])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        self.assertEqual(CofkCollectPerson.objects.count(), 1)
+
+    def test_bulk_people_missing_required(self):
+        """Row without primary_name generates a validation error and no record is created."""
+        row = self._row(birth_year=1600)
+        filename = self.create_bulk_people_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertIn('people', cuef.errors)
+        self.assertEqual(CofkCollectPerson.objects.count(), 0)
+
+    def test_bulk_people_duplicate_skipped(self):
+        """Two rows with the same name (case-insensitive) result in only one record."""
+        rows = [
+            self._row(primary_name='Isaac Newton'),
+            self._row(primary_name='isaac newton'),
+        ]
+        filename = self.create_bulk_people_file(rows)
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        self.assertEqual(CofkCollectPerson.objects.count(), 1)
+
+    def test_bulk_people_invalid_bool(self):
+        """A non-0/1 value for a boolean field generates a validation error."""
+        row = self._row(primary_name='Isaac Newton', birth_inferred=2)
+        filename = self.create_bulk_people_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertIn('people', cuef.errors)
+        self.assertEqual(CofkCollectPerson.objects.count(), 0)
+
+    def test_bulk_people_year_below_minimum(self):
+        """A year below MIN_YEAR (1400) generates a validation error."""
+        row = self._row(primary_name='Isaac Newton', birth_year=1200)
+        filename = self.create_bulk_people_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertIn('people', cuef.errors)
+
+    def test_bulk_people_year_above_maximum(self):
+        """A year above MAX_YEAR (1900) generates a validation error."""
+        row = self._row(primary_name='Someone Recent', death_year=1950)
+        filename = self.create_bulk_people_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertIn('people', cuef.errors)
+
+    def test_bulk_people_bool_fields_accepted(self):
+        """Valid boolean values 0 and 1 are accepted and stored correctly."""
+        row = self._row(
+            primary_name='Isaac Newton',
+            birth_inferred=1,
+            birth_uncertain=0,
+            birth_approx=1,
+            death_inferred=0,
+            fl_range=1,
+        )
+        filename = self.create_bulk_people_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        person = CofkCollectPerson.objects.first()
+        self.assertEqual(person.date_of_birth_inferred, 1)
+        self.assertEqual(person.date_of_birth_uncertain, 0)
+        self.assertEqual(person.date_of_birth_approx, 1)
+        self.assertEqual(person.flourished_is_range, 1)
+
+    def test_bulk_people_flourished_dates(self):
+        """Flourished year range is stored correctly."""
+        row = self._row(primary_name='Anonymous Poet', fl_year=1550, fl2_year=1600, fl_range=1)
+        filename = self.create_bulk_people_file([row])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.errors, {})
+        person = CofkCollectPerson.objects.first()
+        self.assertEqual(person.flourished_year, 1550)
+        self.assertEqual(person.flourished2_year, 1600)
+        self.assertEqual(person.flourished_is_range, 1)
+
+    def test_bulk_people_upload_type_detected(self):
+        """A People-only bulk spreadsheet is detected as upload_type 'people'."""
+        filename = self.create_bulk_people_file([self._row(primary_name='Isaac Newton')])
+
+        cuef = CofkUploadExcelFile(self.new_upload, filename)
+
+        self.assertEqual(cuef.upload_type, 'people')
+
+    def test_both_people_and_places_without_work_raises_error(self):
+        """A file with both People and Places sheets but no Work sheet raises CofkExcelFileError."""
+        wb = Workbook()
+        wb.create_sheet('People')
+        wb.create_sheet('Places')
+        tf = tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False)
+        wb.save(tf.name)
+        self.tmp_files.append(tf.name)
+
+        with self.assertRaises(CofkExcelFileError):
+            CofkUploadExcelFile(self.new_upload, tf.name)

--- a/uploader/test/test_file_upload.py
+++ b/uploader/test/test_file_upload.py
@@ -35,9 +35,12 @@ class TestFileUpload(UploadIncludedTestCase):
         tf = tempfile.NamedTemporaryFile(suffix='.xlsx')
         wb.save(tf.name)
 
-        msg = r'Missing sheets: Manifestation, People, Places, Repositories, Work'
-        self.assertRaisesRegex(CofkExcelFileError, msg, CofkUploadExcelFile,
-                               self.new_upload, tf.name)
+        msg = (r"Could not determine upload type. File must contain either a Work sheet (standard upload),"
+               r" only a People sheet (bulk people), or only a Places sheet (bulk locations).")
+
+        with self.assertRaises(CofkExcelFileError) as ctx:
+            CofkUploadExcelFile(self.new_upload, tf.name)
+        self.assertEqual(str(ctx.exception), msg)
 
     def test_incomplete_headers(self):
         wb = Workbook()
@@ -164,7 +167,6 @@ class TestFileUpload(UploadIncludedTestCase):
         self.assertIn(msg, cuef.errors['people']['errors'][0]['errors'])
         self.assertIn(msg2, cuef.errors['people']['errors'][0]['errors'])
 
-
     def test_mismatching_people_one_exists(self):
         """
         This test replicates the above test except that one of the ids exists in the Union catalogue.
@@ -215,7 +217,7 @@ class TestFileUpload(UploadIncludedTestCase):
             'Manifestation': [[1, 1, "ALS", 2, "Bodleian", "test", "test", '', '', '', '', ''],
                               [2, 1, '', '', '', '', '', "P", "test", "test", '', '']],
             'Repositories': [['Bodleian', 2]]
-            }
+        }
 
         filename = self.create_excel_file(data)
 

--- a/uploader/test/test_review.py
+++ b/uploader/test/test_review.py
@@ -5,15 +5,163 @@ from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 
 from core.constant import REL_TYPE_CREATED
-from uploader.models import CofkCollectUpload
-from uploader.review import accept_works
+from location.models import CofkUnionLocation
+from person.models import CofkUnionPerson
+from uploader.models import CofkCollectLocation, CofkCollectPerson
+from uploader.review import accept_works, accept_locations, accept_people
 from uploader.spreadsheet import CofkUploadExcelFile
-from uploader.test.test_serv import UploadIncludedFactoryTestCase, spreadsheet_data, upload_status, MockMessages
+from uploader.test.test_serv import UploadIncludedFactoryTestCase, UploadIncludedTestCase, \
+    spreadsheet_data, upload_status, MockMessages
 from uploader.uploader_serv import DisplayableCollectWork
 from uploader.views import upload_review
 from work.models import CofkUnionWork
 
 log = logging.getLogger(__name__)
+
+
+class TestAcceptLocations(UploadIncludedTestCase):
+
+    def _make_collect_location(self, **kwargs):
+        defaults = dict(
+            upload=self.new_upload,
+            location_id=1,
+            location_name='London, England',
+            element_1_eg_room='Room 3',
+            element_2_eg_building='The Bell Inn',
+            element_3_eg_parish='St George',
+            element_4_eg_city='London',
+            element_5_eg_county='Middlesex',
+            element_6_eg_country='England',
+            element_7_eg_empire='British Empire',
+            location_synonyms='Londinium',
+            editors_notes='capital city',
+            latitude='51.5074',
+            longitude='-0.1278',
+        )
+        defaults.update(kwargs)
+        return CofkCollectLocation.objects.create(**defaults)
+
+    def test_accept_locations_copies_all_fields(self):
+        """accept_locations copies all fields from CofkCollectLocation to CofkUnionLocation."""
+        self._make_collect_location()
+
+        accept_locations(self.new_upload, username='admin')
+
+        union_loc = CofkUnionLocation.objects.exclude(pk__in=[782, 400285]).get()
+        self.assertEqual(union_loc.location_name, 'London, England')
+        self.assertEqual(union_loc.element_1_eg_room, 'Room 3')
+        self.assertEqual(union_loc.element_2_eg_building, 'The Bell Inn')
+        self.assertEqual(union_loc.element_3_eg_parish, 'St George')
+        self.assertEqual(union_loc.element_4_eg_city, 'London')
+        self.assertEqual(union_loc.element_5_eg_county, 'Middlesex')
+        self.assertEqual(union_loc.element_6_eg_country, 'England')
+        self.assertEqual(union_loc.element_7_eg_empire, 'British Empire')
+        self.assertEqual(union_loc.location_synonyms, 'Londinium')
+        self.assertEqual(union_loc.editors_notes, 'capital city')
+        self.assertEqual(union_loc.latitude, '51.5074')
+        self.assertEqual(union_loc.longitude, '-0.1278')
+
+    def test_accept_locations_links_collect_to_union(self):
+        """accept_locations sets union_location FK on the collect record."""
+        collect_loc = self._make_collect_location()
+
+        accept_locations(self.new_upload, username='admin')
+
+        collect_loc.refresh_from_db()
+        self.assertIsNotNone(collect_loc.union_location)
+
+    def test_accept_locations_name_only(self):
+        """accept_locations works when only location_name is set (no element fields)."""
+        CofkCollectLocation.objects.create(
+            upload=self.new_upload, location_id=1, location_name='Rome',
+        )
+
+        accept_locations(self.new_upload, username='admin')
+
+        union_loc = CofkUnionLocation.objects.exclude(pk__in=[782, 400285]).get()
+        self.assertEqual(union_loc.location_name, 'Rome')
+
+
+class TestAcceptPeople(UploadIncludedTestCase):
+
+    def _make_collect_person(self, **kwargs):
+        defaults = dict(
+            upload=self.new_upload,
+            iperson_id=9001,
+            primary_name='Isaac Newton',
+            gender='M',
+            is_organisation='N',
+            editors_notes='physicist',
+            date_of_birth_year=1643,
+            date_of_birth_month=1,
+            date_of_birth_day=4,
+            date_of_birth_inferred=1,
+            date_of_birth_uncertain=0,
+            date_of_birth_approx=0,
+            date_of_birth_is_range=0,
+            date_of_birth2_year=None,
+            date_of_birth2_month=None,
+            date_of_birth2_day=None,
+            date_of_death_year=1727,
+            date_of_death_month=3,
+            date_of_death_day=31,
+            date_of_death_inferred=0,
+            date_of_death_uncertain=0,
+            date_of_death_approx=0,
+            date_of_death_is_range=0,
+            date_of_death2_year=None,
+            date_of_death2_month=None,
+            date_of_death2_day=None,
+        )
+        defaults.update(kwargs)
+        return CofkCollectPerson.objects.create(**defaults)
+
+    def test_accept_people_copies_all_fields(self):
+        """accept_people copies all fields from CofkCollectPerson to CofkUnionPerson."""
+        self._make_collect_person()
+
+        accept_people(self.new_upload, username='admin')
+
+        union_person = CofkUnionPerson.objects.exclude(iperson_id__in=[15257, 885, 22859]).get()
+        self.assertEqual(union_person.foaf_name, 'Isaac Newton')
+        self.assertEqual(union_person.gender, 'M')
+        self.assertEqual(union_person.is_organisation, 'N')
+        self.assertEqual(union_person.editors_notes, 'physicist')
+        self.assertEqual(union_person.date_of_birth_year, 1643)
+        self.assertEqual(union_person.date_of_birth_month, 1)
+        self.assertEqual(union_person.date_of_birth_day, 4)
+        self.assertEqual(union_person.date_of_birth_inferred, 1)
+        self.assertEqual(union_person.date_of_birth_uncertain, 0)
+        self.assertEqual(union_person.date_of_birth_approx, 0)
+        self.assertEqual(union_person.date_of_birth_is_range, 0)
+        self.assertEqual(union_person.date_of_death_year, 1727)
+        self.assertEqual(union_person.date_of_death_month, 3)
+        self.assertEqual(union_person.date_of_death_day, 31)
+        self.assertEqual(union_person.date_of_death_inferred, 0)
+        self.assertEqual(union_person.date_of_death_uncertain, 0)
+        self.assertEqual(union_person.date_of_death_approx, 0)
+        self.assertEqual(union_person.date_of_death_is_range, 0)
+
+    def test_accept_people_links_collect_to_union(self):
+        """accept_people sets union_iperson FK on the collect record."""
+        collect_person = self._make_collect_person()
+
+        accept_people(self.new_upload, username='admin')
+
+        collect_person.refresh_from_db()
+        self.assertIsNotNone(collect_person.union_iperson)
+
+    def test_accept_people_name_only(self):
+        """accept_people works when only primary_name is set."""
+        CofkCollectPerson.objects.create(
+            upload=self.new_upload, iperson_id=9001,
+            primary_name='John Doe', gender='', is_organisation='',
+        )
+
+        accept_people(self.new_upload, username='admin')
+
+        union_person = CofkUnionPerson.objects.exclude(iperson_id__in=[15257, 885, 22859]).get()
+        self.assertEqual(union_person.foaf_name, 'John Doe')
 
 
 class TestReview(UploadIncludedFactoryTestCase):

--- a/uploader/validation.py
+++ b/uploader/validation.py
@@ -121,7 +121,7 @@ class CofkValidateWork:
             self.add_error("There is neither a destination_id nor a destination_name.",
                            ', '.join([destination_id.key, destination_name.key]))
 
-        if not (origin_id or origin_name):
+        if not (origin_id.value or origin_name.value):
             self.add_error("There is neither a origin_id nor a origin_name.",
                            ', '.join([origin_id.key, origin_name.key]))
 
@@ -175,12 +175,12 @@ def validate_manifestation(df):
                 m_errors.append(CofkValueException('There should be an en dash used between folio numbers,'
                                                    ' not a hyphen.', 'id_number_or_shelfmark'))
 
-            if manifestation['id_number_or_shelfmark'][-1] != '.':
+            if manifestation['id_number_or_shelfmark'] and manifestation['id_number_or_shelfmark'][-1] != '.':
                 m_errors.append(CofkValueException('There should not be a full stop at the end of'
                                                    ' a shelfmark.', 'id_number_or_shelfmark'))
 
         if 'printed_edition_details' in manifestation:
-            if manifestation['printed_edition_details'][-1] == '.':
+            if manifestation['printed_edition_details'] and manifestation['printed_edition_details'][-1] == '.':
                 m_errors.append(CofkValueException('There should not be a full stop at the end of bibliographic'
                                                    ' details of a manifestation.', 'printed_edition_details'))
 

--- a/uploader/validation.py
+++ b/uploader/validation.py
@@ -32,6 +32,8 @@ class CofkValidateWork:
         self.errors = []
 
         self.validate_dates()
+        self.validate_places()
+        self.validate_keywords()
 
     def get_value(self, key) -> CofkValue:
         value = {'key': key, 'value': None}

--- a/uploader/validation.py
+++ b/uploader/validation.py
@@ -50,7 +50,7 @@ class CofkValidateWork:
 
         # Make sure month is between 1-12
         if m.value is not None and not 0 < m.value < 13:
-            self.add_error('{} is {} but must be between 1 and 12'.format(m.key, m.value), y.key)
+            self.add_error('{} is {} but must be between 1 and 12'.format(m.key, m.value), m.key)
 
         # Check day of month
         if d.value is not None:
@@ -83,29 +83,32 @@ class CofkValidateWork:
 
         # Date is a range, switch between Julian to Gregorian calendar was around October 1582.
         # This could get sticky.
-        if date_of_work_std_is_range == 1:
+        if date_of_work_std_is_range.value == 1:
             date_of_work2_std_year = self.get_value('date_of_work2_std_year')
             date_of_work2_std_month = self.get_value('date_of_work2_std_month')
             date_of_work2_std_day = self.get_value('date_of_work2_std_day')
 
             self.validate_date(date_of_work2_std_year, date_of_work2_std_month, date_of_work2_std_day)
 
-            first_date = datetime.datetime(date_of_work_std_year.value,
-                                           date_of_work_std_month.value, date_of_work_std_day.value)
-            second_date = datetime.datetime(date_of_work2_std_year.value,
-                                            date_of_work2_std_month.value, date_of_work2_std_day.value)
+            range_values = [date_of_work_std_year, date_of_work_std_month, date_of_work_std_day,
+                            date_of_work2_std_year, date_of_work2_std_month, date_of_work2_std_day]
+            if all(v.value is not None for v in range_values):
+                first_date = datetime.datetime(date_of_work_std_year.value,
+                                               date_of_work_std_month.value, date_of_work_std_day.value)
+                second_date = datetime.datetime(date_of_work2_std_year.value,
+                                                date_of_work2_std_month.value, date_of_work2_std_day.value)
 
-            if first_date >= second_date:
-                cols = [date_of_work_std_year.key, date_of_work_std_month.key, date_of_work_std_day.key,
-                        date_of_work2_std_year.key, date_of_work2_std_month.key, date_of_work2_std_day.key]
-                self.add_error("The start date in a date range can not be after the end date.", ', '.join(cols))
+                if first_date >= second_date:
+                    cols = [date_of_work_std_year.key, date_of_work_std_month.key, date_of_work_std_day.key,
+                            date_of_work2_std_year.key, date_of_work2_std_month.key, date_of_work2_std_day.key]
+                    self.add_error("The start date in a date range can not be after the end date.", ', '.join(cols))
 
         notes_on_date_of_work = self.get_value('notes_on_date_of_work')
 
-        if notes_on_date_of_work.value is not None and notes_on_date_of_work.value[0].islower():
+        if notes_on_date_of_work.value and notes_on_date_of_work.value[0].islower():
             self.add_error("Notes with dates have to start with an upper case letter.", notes_on_date_of_work.key)
 
-        if notes_on_date_of_work.value is not None and notes_on_date_of_work.value[-1] != '.':
+        if notes_on_date_of_work.value and notes_on_date_of_work.value[-1] != '.':
             self.add_error("Notes with dates have to end with a full stop.", notes_on_date_of_work.key)
 
     def validate_places(self):
@@ -134,7 +137,7 @@ class CofkValidateWork:
     def validate_keywords(self):
         keywords = self.get_value('keywords')
 
-        if len(keywords.value.split('; ')) - 1 != keywords.value.count(';'):
+        if keywords.value and len(keywords.value.split('; ')) - 1 != keywords.value.count(';'):
             self.add_error("Not all keywords are properly separated with a space after the separator, ;.", keywords.key)
 
 

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -181,7 +181,10 @@ def lookup_fn_date_of_work(lookup_fn, field_name, value):
     value = str(value).strip()
     query = Q()
     date_pattern = r'^([\d\?]{4})(?:-([\d]{2}|[\?]{2}))?(?:-([\d]{2}|[\?]{2}))?$'
-    matches = [re.search(date_pattern, v) for v in value.split(' to ')]
+    matches = [re.search(date_pattern, v.strip()) for v in value.split(' to ')]
+
+    if any(m is None for m in matches):
+        return Q(pk=0)
 
     if len(matches) == 1:
         year = matches[0].group(1)

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -25,7 +25,7 @@ from core.helper.view_serv import DefaultSearchView
 from core.models import CofkLookupCatalogue, CofkLookupDocumentType
 from uploader.forms import CofkCollectUploadForm, GeneralSearchFieldset
 from uploader.models import CofkCollectUpload, CofkCollectPerson, CofkCollectLocation
-from uploader.review import reject_works
+from uploader.review import reject_works, accept_people, reject_people, accept_locations, reject_locations
 from uploader.uploader_serv import DisplayableCollectWork
 
 log = logging.getLogger(__name__)
@@ -115,8 +115,18 @@ class AddUploadView(TemplateView):
 @login_required
 @permission_required(constant.PM_CHANGE_COLLECTWORK, raise_exception=True)
 def upload_review(request, upload_id, **kwargs):
-    template_url = 'uploader/review.html'
     upload: CofkCollectUpload = CofkCollectUpload.objects.filter(pk=upload_id).first()
+
+    if upload.upload_type == 'people':
+        return _upload_review_people(request, upload)
+    elif upload.upload_type == 'location':
+        return _upload_review_locations(request, upload)
+
+    return _upload_review_works(request, upload)
+
+
+def _upload_review_works(request, upload: CofkCollectUpload):
+    template_url = 'uploader/review.html'
 
     prefetch = ['authors', 'addressees', 'people_mentioned', 'languages', 'subjects', 'manifestations', 'resources',
                 'upload_status', 'addressees__iperson', 'authors__iperson', 'people_mentioned__iperson',
@@ -141,7 +151,6 @@ def upload_review(request, upload_id, **kwargs):
     people = CofkCollectPerson.objects.filter(upload=upload, union_iperson__isnull=True)
     places = CofkCollectLocation.objects.filter(upload=upload, union_location__isnull=True)
 
-    # TODO, are all of these required for context?
     context = {'username': request.user.username,
                'upload': upload,
                'works_page': works_page,
@@ -153,8 +162,6 @@ def upload_review(request, upload_id, **kwargs):
                'per_page_options': [1000, 2500, 5000]
                }
 
-    # copy variables onto context because we can't pickle the request object which means
-    # it can't be passed to Django Q2
     for prop in ['work_id', 'accession_code', 'catalogue_code']:
         if prop in request.POST:
             context[prop] = request.POST[prop]
@@ -175,6 +182,40 @@ def upload_review(request, upload_id, **kwargs):
             reject_works(context, upload, request)
 
     return render(request, template_url, context)
+
+
+def _upload_review_people(request, upload: CofkCollectUpload):
+    if 'confirm' in request.POST and 'action' in request.POST:
+        if request.POST['action'] == 'accept':
+            accept_people(upload, request.user.username, request)
+            return redirect(reverse('uploader:upload_list'))
+        elif request.POST['action'] == 'reject':
+            reject_people(upload, request)
+            return redirect(reverse('uploader:upload_list'))
+
+    people = CofkCollectPerson.objects.filter(upload=upload).order_by('iperson_id')
+    context = {
+        'upload': upload,
+        'people': people,
+    }
+    return render(request, 'uploader/review_people.html', context)
+
+
+def _upload_review_locations(request, upload: CofkCollectUpload):
+    if 'confirm' in request.POST and 'action' in request.POST:
+        if request.POST['action'] == 'accept':
+            accept_locations(upload, request.user.username, request)
+            return redirect(reverse('uploader:upload_list'))
+        elif request.POST['action'] == 'reject':
+            reject_locations(upload, request)
+            return redirect(reverse('uploader:upload_list'))
+
+    locations = CofkCollectLocation.objects.filter(upload=upload).order_by('location_id')
+    context = {
+        'upload': upload,
+        'locations': locations,
+    }
+    return render(request, 'uploader/review_locations.html', context)
 
 
 def lookup_fn_date_of_work(lookup_fn, field_name, value):


### PR DESCRIPTION
fixes https://github.com/culturesofknowledge/emlo-project/issues/321

This PR adds the feature to upload in bulk only people or only locations.

Examples of the spreadsheets that can be uploaded can be found in the linked issue.

The review process for locations/people is all or nothing, it is not possible to cherry pick from locations or people uploads the same way as it is for works.

<img width="1098" height="318" alt="image" src="https://github.com/user-attachments/assets/214517df-e84c-41f4-a8ef-b186a2c35d14" />

The upload introduces a new property for the upload model, the upload_type which is by default "work" but can be "people" or "location".

There are unit tests added