### PR TITLE
Feature/bulk corrections

### DIFF
--- a/uploader/constants.py
+++ b/uploader/constants.py
@@ -114,6 +114,65 @@ MANDATORY_SHEETS = {
 MAX_YEAR = 1900
 MIN_YEAR = 1400
 
+# Column definitions for bulk work corrections upload.
+# Sheet name is lowercase 'work' (distinguishes from the standard 'Work' new-works upload).
+# Keys are the exact spreadsheet column header strings; values are CofkUnionWork field names.
+# 'Original Catalogue name' is a special FK field requiring a CofkLookupCatalogue lookup.
+# Columns not present in this dict (e.g. Author, Recipient full names, Languages) are ignored.
+CORRECTION_WORK_SHEET = {
+    'identifier': 'EMLO Letter ID Number',
+    'command_col': 'Command',
+    'columns': {
+        'Year date': 'date_of_work_std_year',
+        'Month date': 'date_of_work_std_month',
+        'Day date': 'date_of_work_std_day',
+        'Date is range (0=No; 1=Yes)': 'date_of_work_std_is_range',
+        'Year 2nd date (range)': 'date_of_work2_std_year',
+        'Month 2nd date (range)': 'date_of_work2_std_month',
+        'Day 2nd date (range)': 'date_of_work2_std_day',
+        'Calendar of date provided to EMLO (G=Gregorian; JJ=Julian, year start 1 January; JM=Julian, year start March, U=Unknown)': 'original_calendar',
+        'Date as marked on letter': 'date_of_work_as_marked',
+        'Date uncertain (0=No; 1=Yes)': 'date_of_work_uncertain',
+        'Date approximate (0=No; 1=Yes)': 'date_of_work_approx',
+        'Date inferred (0=No; 1=Yes)': 'date_of_work_inferred',
+        'Notes on date': 'notes_on_date_of_work',
+        'Author as marked in body/text of letter': 'authors_as_marked',
+        'Author inferred (0=No; 1=Yes)': 'authors_inferred',
+        'Author uncertain (0=No; 1=Yes)': 'authors_uncertain',
+        'Recipient as marked in body/text of letter': 'addressees_as_marked',
+        'Recipient inferred (0=No; 1=Yes)': 'addressees_inferred',
+        'Recipient uncertain (0=No; 1=Yes)': 'addressees_uncertain',
+        'Origin as marked in body/text of letter': 'origin_as_marked',
+        'Origin inferred (0=No; 1=Yes)': 'origin_inferred',
+        'Origin uncertain (0=No; 1=Yes)': 'origin_uncertain',
+        'Destination as marked in body/text of letter': 'destination_as_marked',
+        'Destination inferred (0=No; 1=Yes)': 'destination_inferred',
+        'Destination uncertain (0=No; 1=Yes)': 'destination_uncertain',
+        'Abstract': 'abstract',
+        'Keywords': 'keywords',
+        'Incipit': 'incipit',
+        'Explicit': 'explicit',
+        'Original Catalogue name': 'original_catalogue',  # FK — resolved via CofkLookupCatalogue
+        'Source': 'accession_code',
+        'General notes for public display': 'notes_on_letter',
+        "Editors' working notes": 'editors_notes',
+    },
+    'ints': [
+        'date_of_work_std_year', 'date_of_work_std_month', 'date_of_work_std_day',
+        'date_of_work2_std_year', 'date_of_work2_std_month', 'date_of_work2_std_day',
+    ],
+    'bools': [
+        'date_of_work_std_is_range', 'date_of_work_uncertain', 'date_of_work_approx',
+        'date_of_work_inferred', 'authors_inferred', 'authors_uncertain',
+        'addressees_inferred', 'addressees_uncertain',
+        'origin_inferred', 'origin_uncertain', 'destination_inferred', 'destination_uncertain',
+    ],
+    'years': ['date_of_work_std_year', 'date_of_work2_std_year'],
+    'months': ['date_of_work_std_month', 'date_of_work2_std_month'],
+    'dates': ['date_of_work_std_day', 'date_of_work2_std_day'],
+    'fk_fields': ['original_catalogue'],
+}
+
 # Column definitions for bulk People upload (BULKnewPEOPLErecordsTEMPLATE format).
 # Columns are mapped by position (index) rather than by matching header text, because the
 # template uses verbose human-readable column headers.

--- a/uploader/entities/corrections.py
+++ b/uploader/entities/corrections.py
@@ -22,8 +22,8 @@ class CofkWorkCorrections(CofkEntity):
     and supplies one or more correction fields. Corrections are stored as a JSON dict
     {field_name: new_value} on CofkCollectWorkCorrection.
 
-    'Original Catalogue name' is resolved to a CofkLookupCatalogue catalogue_code and
-    stored under the key 'original_catalogue_code' to avoid FK serialisation issues.
+    'Original Catalogue name' expects a catalogue_code value (e.g. 'EMLO') which is
+    validated against CofkLookupCatalogue and stored under 'original_catalogue_code'.
     """
 
     @property

--- a/uploader/entities/corrections.py
+++ b/uploader/entities/corrections.py
@@ -1,0 +1,183 @@
+import logging
+from typing import List
+
+from core.models import CofkLookupCatalogue
+from uploader.constants import CORRECTION_WORK_SHEET, MAX_YEAR, MIN_YEAR
+from uploader.entities.entity import CofkEntity
+from uploader.models import CofkCollectUpload, CofkCollectWorkCorrection
+from work.models import CofkUnionWork
+
+log = logging.getLogger(__name__)
+
+IDENTIFIER_COL = CORRECTION_WORK_SHEET['identifier']   # 'EMLO Letter ID Number'
+COMMAND_COL    = CORRECTION_WORK_SHEET['command_col']  # 'Command'
+COL_TO_FIELD   = CORRECTION_WORK_SHEET['columns']      # exact header -> CofkUnionWork field name
+
+
+class CofkWorkCorrections(CofkEntity):
+    """
+    Parses a bulk work corrections spreadsheet (lowercase 'work' sheet, 1 header row).
+
+    Each data row identifies an existing CofkUnionWork via 'EMLO Letter ID Number'
+    and supplies one or more correction fields. Corrections are stored as a JSON dict
+    {field_name: new_value} on CofkCollectWorkCorrection.
+
+    'Original Catalogue name' is resolved to a CofkLookupCatalogue catalogue_code and
+    stored under the key 'original_catalogue_code' to avoid FK serialisation issues.
+    """
+
+    @property
+    def fields(self) -> dict:
+        return CORRECTION_WORK_SHEET
+
+    def __init__(self, upload: CofkCollectUpload, sheet):
+        super().__init__(upload, sheet)
+        self.corrections: List[CofkCollectWorkCorrection] = []
+
+        header = sheet.header  # list of column name strings from row 1
+
+        for row_number, row in enumerate(sheet.worksheet.iter_rows(), start=1):
+            if row_number <= sheet.header_length:
+                continue
+
+            row_by_header = {
+                header[cell.column - 1]: cell.value
+                for cell in row
+                if cell.column <= len(header) and cell.value not in (None, '')
+            }
+
+            if not row_by_header:
+                continue
+
+            self.row = row_number
+
+            # --- Identify the work ---
+            if IDENTIFIER_COL not in row_by_header:
+                self.add_error(f'Row {row_number}: missing required column "{IDENTIFIER_COL}".')
+                continue
+
+            try:
+                iwork_id = int(row_by_header[IDENTIFIER_COL])
+                if iwork_id < 1:
+                    raise ValueError
+            except (ValueError, TypeError):
+                self.add_error(
+                    f'Row {row_number}: "{IDENTIFIER_COL}" value '
+                    f'"{row_by_header[IDENTIFIER_COL]}" is not a valid positive integer.'
+                )
+                continue
+
+            command = str(row_by_header.get(COMMAND_COL, 'UPDATE')).strip().upper()
+            if command != 'UPDATE':
+                self.add_error(
+                    f'Row {row_number}: Command "{command}" is not supported. Only "UPDATE" is allowed.'
+                )
+                continue
+
+            try:
+                union_work = CofkUnionWork.objects.get(iwork_id=iwork_id)
+            except CofkUnionWork.DoesNotExist:
+                self.add_error(
+                    f'Row {row_number}: no work found with EMLO Letter ID Number {iwork_id}.'
+                )
+                continue
+
+            if iwork_id in self.ids:
+                log.warning(f'Duplicate iwork_id {iwork_id} in correction sheet — skipping row {row_number}.')
+                continue
+
+            # --- Build corrections dict ---
+            corrections_dict = {}
+            has_error = False
+
+            for col_header, field_name in COL_TO_FIELD.items():
+                if col_header not in row_by_header:
+                    continue
+                raw = row_by_header[col_header]
+
+                if field_name in CORRECTION_WORK_SHEET.get('ints', []):
+                    try:
+                        raw = int(raw)
+                    except (ValueError, TypeError):
+                        self.add_error(
+                            f'Row {row_number}: "{col_header}" must be an integer (got "{raw}").'
+                        )
+                        has_error = True
+                        break
+
+                if field_name in CORRECTION_WORK_SHEET.get('bools', []):
+                    try:
+                        v = int(raw)
+                        if v not in (0, 1):
+                            raise ValueError
+                        raw = v
+                    except (ValueError, TypeError):
+                        self.add_error(
+                            f'Row {row_number}: "{col_header}" must be 0 or 1 (got "{raw}").'
+                        )
+                        has_error = True
+                        break
+
+                if field_name in CORRECTION_WORK_SHEET.get('years', []) and isinstance(raw, int):
+                    if not MIN_YEAR <= raw <= MAX_YEAR:
+                        self.add_error(
+                            f'Row {row_number}: "{col_header}" year {raw} must be between '
+                            f'{MIN_YEAR} and {MAX_YEAR}.'
+                        )
+                        has_error = True
+                        break
+
+                if field_name in CORRECTION_WORK_SHEET.get('months', []) and isinstance(raw, int):
+                    if not 1 <= raw <= 12:
+                        self.add_error(
+                            f'Row {row_number}: "{col_header}" month {raw} must be between 1 and 12.'
+                        )
+                        has_error = True
+                        break
+
+                if field_name in CORRECTION_WORK_SHEET.get('dates', []) and isinstance(raw, int):
+                    if raw > 31:
+                        self.add_error(
+                            f'Row {row_number}: "{col_header}" day {raw} cannot exceed 31.'
+                        )
+                        has_error = True
+                        break
+
+                if field_name == 'original_catalogue':
+                    catalogue = CofkLookupCatalogue.objects.filter(
+                        catalogue_code__iexact=str(raw).strip()
+                    ).first()
+                    if catalogue is None:
+                        self.add_error(
+                            f'Row {row_number}: catalogue "{raw}" not found in the lookup table.'
+                        )
+                        has_error = True
+                        break
+                    # Store the catalogue_code string (used as FK value via original_catalogue_id)
+                    corrections_dict['original_catalogue_code'] = catalogue.catalogue_code
+                    continue
+
+                corrections_dict[field_name] = raw
+
+            if has_error:
+                continue
+
+            if not corrections_dict:
+                log.warning(f'Row {row_number}: iwork_id {iwork_id} — no correction columns found, skipping.')
+                continue
+
+            self.ids.append(iwork_id)
+            self.corrections.append(
+                CofkCollectWorkCorrection(
+                    upload=upload,
+                    iwork_id=iwork_id,
+                    union_work=union_work,
+                    corrections=corrections_dict,
+                    upload_status_id=1,
+                )
+            )
+
+        log.info(
+            f'{upload}: parsed {len(self.corrections)} corrections, '
+            f'{sum(len(v) for v in self.errors.values())} errors.'
+        )

--- a/uploader/models.py
+++ b/uploader/models.py
@@ -51,7 +51,7 @@ class CofkCollectUpload(models.Model):
     _id = models.CharField(max_length=32, blank=True, null=True)
     upload_name = models.CharField(max_length=254, blank=True, null=True)
     upload_file = models.FileField(upload_to=user_directory_path, blank=True, null=True)  # schema changed
-    upload_type = models.CharField(max_length=20, default='work')  # 'work' | 'people' | 'location'
+    upload_type = models.CharField(max_length=20, default='work')  # 'work' | 'people' | 'location' | 'correction'
 
     class Meta:
         db_table = 'cofk_collect_upload'
@@ -506,3 +506,23 @@ class CofkCollectWorkResource(models.Model):
     class Meta:
         db_table = 'cofk_collect_work_resource'
         unique_together = (('upload', 'iwork_id', 'resource_id'),)
+
+
+class CofkCollectWorkCorrection(models.Model):
+    """Staging record for a bulk correction to an existing CofkUnionWork."""
+    upload = models.ForeignKey(
+        'uploader.CofkCollectUpload', on_delete=models.CASCADE, related_name='corrections',
+    )
+    iwork_id = models.IntegerField()
+    union_work = models.ForeignKey(
+        'work.CofkUnionWork', on_delete=models.SET_NULL,
+        blank=True, null=True, to_field='iwork_id', related_name='collect_corrections',
+    )
+    corrections = models.JSONField()  # {field_name: new_value}; catalogue FK stored as 'original_catalogue_code'
+    upload_status = models.ForeignKey(
+        CofkCollectStatus, on_delete=models.SET_NULL, db_column='upload_status', null=True,
+    )
+
+    class Meta:
+        db_table = 'cofk_collect_work_correction'
+        unique_together = (('upload', 'iwork_id'),)

--- a/uploader/review.py
+++ b/uploader/review.py
@@ -21,7 +21,8 @@ from location.models import CofkUnionLocation
 from manifestation import manif_serv
 from manifestation.models import CofkUnionManifestation, CofkManifInstMap
 from person.models import CofkUnionPerson, create_person_id
-from uploader.models import CofkCollectUpload, CofkCollectWork, CofkCollectPerson, CofkCollectLocation
+from uploader.models import CofkCollectUpload, CofkCollectWork, CofkCollectPerson, CofkCollectLocation, \
+    CofkCollectWorkCorrection
 from work.models import CofkUnionWork, CofkWorkLocationMap, CofkWorkPersonMap, CofkWorkResourceMap, \
     CofkUnionLanguageOfWork, CofkWorkSubjectMap, CofkWorkCommentMap
 
@@ -503,6 +504,70 @@ def reject_locations(upload: CofkCollectUpload, request=None):
     if request:
         messages.success(request, msg)
     log.info(f'{upload}: rejected (locations bulk upload)')
+
+
+def accept_corrections(upload: CofkCollectUpload, username: str, request=None):
+    """Accept a bulk corrections upload — apply each staged correction to the live CofkUnionWork."""
+    pending = CofkCollectWorkCorrection.objects.filter(
+        upload=upload, upload_status_id=1
+    ).select_related('union_work')
+
+    if not pending.exists():
+        msg = f'No corrections in the upload "{upload.upload_name}" to accept.'
+        if request:
+            messages.warning(request, msg)
+        return
+
+    try:
+        with transaction.atomic():
+            applied = 0
+            for correction in pending:
+                if correction.union_work is None:
+                    log.warning(
+                        f'Skipping correction for iwork_id {correction.iwork_id}: union_work not found.'
+                    )
+                    continue
+
+                work = correction.union_work
+                for field_name, new_value in correction.corrections.items():
+                    if field_name == 'original_catalogue_code':
+                        # catalogue_code is stored as the FK value (to_field='catalogue_code')
+                        setattr(work, 'original_catalogue_id', new_value)
+                    else:
+                        setattr(work, field_name, new_value)
+                work.update_current_user_timestamp(username)
+                work.save()
+
+                correction.upload_status_id = 4  # Accepted and saved into main database
+                correction.save()
+                applied += 1
+
+            upload.works_accepted = applied
+            upload.upload_status_id = 4  # Accepted and saved into main database
+            upload.save()
+
+    except Exception as e:
+        log.error(f'Bulk corrections upload {upload} failed.')
+        log.exception(e)
+        if request:
+            messages.error(request, 'An error occurred while accepting corrections. Please try again.')
+        return
+
+    msg = f'Successfully applied {applied} corrections.'
+    if request:
+        messages.success(request, msg)
+    log.info(f'{upload}: {msg}')
+
+
+def reject_corrections(upload: CofkCollectUpload, request=None):
+    """Reject a bulk corrections upload."""
+    CofkCollectWorkCorrection.objects.filter(upload=upload).update(upload_status_id=5)
+    upload.upload_status_id = 3  # Review complete
+    upload.save()
+    msg = f'Upload "{upload.upload_name}" has been rejected.'
+    if request:
+        messages.success(request, msg)
+    log.info(f'{upload}: rejected (corrections upload)')
 
 
 def reject_works(context: dict, upload: CofkCollectUpload, request):

--- a/uploader/spreadsheet.py
+++ b/uploader/spreadsheet.py
@@ -7,6 +7,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 
 from uploader.constants import MANDATORY_SHEETS
 from uploader.entities.entity import CofkEntity
+from uploader.entities.corrections import CofkWorkCorrections
 from uploader.entities.locations import CofkLocations, CofkBulkLocations
 from uploader.entities.manifestations import CofkManifestations
 from uploader.entities.people import CofkPeople, CofkBulkPeople
@@ -64,6 +65,8 @@ class CofkUploadExcelFile:
             self._process_people_only()
         elif self.upload_type == 'location':
             self._process_locations_only()
+        elif self.upload_type == 'correction':
+            self._process_correction_upload()
 
     def check_sheets(self) -> str:
         """Determine upload type from sheets present. Returns 'work', 'people', or 'location'."""
@@ -80,6 +83,8 @@ class CofkUploadExcelFile:
             return 'people'
         elif 'Places' in present and 'People' not in present:
             return 'location'
+        elif 'work' in present:  # lowercase 'work' sheet = bulk corrections to existing works
+            return 'correction'
         else:
             msg = ('Could not determine upload type. File must contain either a Work sheet '
                    '(standard upload), only a People sheet (bulk people), or only a Places sheet '
@@ -248,3 +253,29 @@ class CofkUploadExcelFile:
             self.sheets['Places'].entities.bulk_create(locations)
             fmt = 'bulk locations' if is_bulk else 'locations'
             log.info(f'{self.upload}: created {len(locations)} CofkCollectLocation ({fmt} upload)')
+
+    def _process_correction_upload(self):
+        """Process a bulk work corrections upload (lowercase 'work' sheet, 1 header row)."""
+        try:
+            sheet = CofkSheet(self.wb['work'])
+        except StopIteration:
+            raise CofkExcelFileError('Corrections sheet "work" is missing its header row.')
+
+        # Correction spreadsheet has 1 header row; standard uploads have 2.
+        # Override so the entity parser skips only row 1 (the header) not row 2 (first data row).
+        sheet.header_length = 1
+
+        self.sheets['work'] = sheet
+        self.sheets['work'].entities = CofkWorkCorrections(upload=self.upload, sheet=sheet)
+
+        if self.sheets['work'].entities.errors:
+            self.errors['corrections'] = self.sheets['work'].entities.format_errors_for_template()
+            self.total_errors += self.errors['corrections']['total']
+
+        if self.total_errors == 0:
+            corrections = self.sheets['work'].entities.corrections
+            if not corrections:
+                raise CofkExcelFileError('Corrections sheet contains no valid data rows.')
+            self.sheets['work'].entities.bulk_create(corrections)
+            self.upload.total_works = len(corrections)
+            log.info(f'{self.upload}: created {len(corrections)} CofkCollectWorkCorrection')

--- a/uploader/spreadsheet.py
+++ b/uploader/spreadsheet.py
@@ -83,7 +83,7 @@ class CofkUploadExcelFile:
             return 'people'
         elif 'Places' in present and 'People' not in present:
             return 'location'
-        elif 'work' in present:  # lowercase 'work' sheet = bulk corrections to existing works
+        elif 'Corrections' in present:
             return 'correction'
         else:
             msg = ('Could not determine upload type. File must contain either a Work sheet '
@@ -255,27 +255,27 @@ class CofkUploadExcelFile:
             log.info(f'{self.upload}: created {len(locations)} CofkCollectLocation ({fmt} upload)')
 
     def _process_correction_upload(self):
-        """Process a bulk work corrections upload (lowercase 'work' sheet, 1 header row)."""
+        """Process a bulk work corrections upload ('Corrections' sheet, 1 header row)."""
         try:
-            sheet = CofkSheet(self.wb['work'])
+            sheet = CofkSheet(self.wb['Corrections'])
         except StopIteration:
-            raise CofkExcelFileError('Corrections sheet "work" is missing its header row.')
+            raise CofkExcelFileError('Corrections sheet is missing its header row.')
 
         # Correction spreadsheet has 1 header row; standard uploads have 2.
         # Override so the entity parser skips only row 1 (the header) not row 2 (first data row).
         sheet.header_length = 1
 
-        self.sheets['work'] = sheet
-        self.sheets['work'].entities = CofkWorkCorrections(upload=self.upload, sheet=sheet)
+        self.sheets['Corrections'] = sheet
+        self.sheets['Corrections'].entities = CofkWorkCorrections(upload=self.upload, sheet=sheet)
 
-        if self.sheets['work'].entities.errors:
-            self.errors['corrections'] = self.sheets['work'].entities.format_errors_for_template()
+        if self.sheets['Corrections'].entities.errors:
+            self.errors['corrections'] = self.sheets['Corrections'].entities.format_errors_for_template()
             self.total_errors += self.errors['corrections']['total']
 
         if self.total_errors == 0:
-            corrections = self.sheets['work'].entities.corrections
+            corrections = self.sheets['Corrections'].entities.corrections
             if not corrections:
                 raise CofkExcelFileError('Corrections sheet contains no valid data rows.')
-            self.sheets['work'].entities.bulk_create(corrections)
+            self.sheets['Corrections'].entities.bulk_create(corrections)
             self.upload.total_works = len(corrections)
             log.info(f'{self.upload}: created {len(corrections)} CofkCollectWorkCorrection')

--- a/uploader/templates/uploader/review_corrections.html
+++ b/uploader/templates/uploader/review_corrections.html
@@ -1,0 +1,74 @@
+{% extends "core/emlo_logined.html" %}
+{% load static %}
+
+{% block content %}
+
+<div id="upload-header">
+    <span id="upload-title">Bulk corrections upload by {{ upload.upload_username }} uploaded {{ upload.upload_timestamp }}</span>
+    <span id="upload-summary">Status: {{ upload.upload_status }} | Corrections in upload: {{ corrections_count }}</span>
+
+    <div class="padding-top">
+        Back to list of contributions
+        <button type="button" class="btn inline_btn" onclick="location.href='/upload'">Back</button>
+
+        <button class="btn inline_btn" id="accept_all"
+                onclick="document.getElementById('confirm').style.display='block';
+                         document.getElementById('confirm_title').textContent='Accept {{ corrections_count }} correction(s)?';
+                         document.getElementById('action').value='accept';">Accept all</button>
+        <button class="btn inline_btn" id="reject_all"
+                onclick="document.getElementById('confirm').style.display='block';
+                         document.getElementById('confirm_title').textContent='Reject all corrections?';
+                         document.getElementById('action').value='reject';">Reject all</button>
+    </div>
+    <em>Note: confirmation will be required before Accept/Reject.</em>
+</div>
+
+{% include "core/component/messages.html" %}
+
+<form method="post">
+    {% csrf_token %}
+    <fieldset id="confirm" style="max-width: 50%; margin-top: 1em; display: none;">
+        <h2 id="confirm_title"></h2>
+        <p>Accepting will apply the proposed values to the live database. This cannot be undone.</p>
+        <input type="hidden" value="" name="action" id="action"/>
+        <button class="btn inline_btn" name="confirm">Confirm</button>
+        <button type="button" class="btn inline_btn"
+                onclick="document.getElementById('confirm').style.display='none';">Cancel</button>
+    </fieldset>
+</form>
+
+<div id="review">
+    <h2>Corrections ({{ corrections_count }})</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>EMLO Letter ID</th>
+                <th>Work</th>
+                <th>Field</th>
+                <th>Current value</th>
+                <th>Proposed new value</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in correction_rows %}
+            <tr>
+                <td>{{ row.iwork_id }}</td>
+                <td>
+                    {% if row.work_id %}
+                        <a href="/work/{{ row.work_id }}">{{ row.work_desc|default:row.work_id }}</a>
+                    {% else %}
+                        <span class="text-danger">Work not found</span>
+                    {% endif %}
+                </td>
+                <td>{{ row.field }}</td>
+                <td>{{ row.old_value|default:"—" }}</td>
+                <td>{{ row.new_value }}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="5">No corrections in this upload.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% endblock %}

--- a/uploader/test/test_corrections.py
+++ b/uploader/test/test_corrections.py
@@ -1,0 +1,330 @@
+import logging
+import tempfile
+
+from openpyxl.workbook import Workbook
+
+from core.models import CofkLookupCatalogue
+from uploader.models import CofkCollectWorkCorrection
+from uploader.review import accept_corrections, reject_corrections
+from uploader.spreadsheet import CofkUploadExcelFile
+from uploader.test.test_serv import UploadIncludedFactoryTestCase
+from uploader.validation import CofkExcelFileError
+from work.models import CofkUnionWork
+
+log = logging.getLogger(__name__)
+
+CORRECTION_HEADERS = ['EMLO Letter ID Number', 'Command', 'Original Catalogue name']
+
+
+class TestCorrectionUpload(UploadIncludedFactoryTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.test_work = CofkUnionWork.objects.create(
+            work_id='work_test_corrections_001',
+            iwork_id=9901,
+            creation_user='test',
+            change_user='test',
+        )
+        self.test_work2 = CofkUnionWork.objects.create(
+            work_id='work_test_corrections_002',
+            iwork_id=9902,
+            creation_user='test',
+            change_user='test',
+        )
+        self.catalogue = CofkLookupCatalogue.objects.create(
+            catalogue_code='TESTCAT',
+            catalogue_name='Test Catalogue',
+            is_in_union=0,
+            publish_status=0,
+        )
+        self.tmp_files = []
+
+    def tearDown(self):
+        super().tearDown()
+
+    def _make_file(self, header_row, data_rows, sheet_name='work'):
+        wb = Workbook()
+        ws = wb.create_sheet(sheet_name)
+        ws.append(header_row)
+        for row in data_rows:
+            ws.append(row)
+        tf = tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False)
+        wb.save(tf.name)
+        self.tmp_files.append(tf.name)
+        return tf.name
+
+    # --- Upload type detection ---
+
+    def test_correction_upload_type_detected(self):
+        """Lowercase 'work' sheet is detected as 'correction' upload type."""
+        path = self._make_file(
+            CORRECTION_HEADERS,
+            [[9901, 'UPDATE', 'Test Catalogue']],
+        )
+        cuef = CofkUploadExcelFile(self.new_upload, path)
+        self.assertEqual(cuef.upload_type, 'correction')
+
+    def test_standard_work_sheet_not_confused_with_correction(self):
+        """Uppercase 'Work' sheet is NOT treated as correction upload."""
+        path = self._make_file(
+            CORRECTION_HEADERS,
+            [[9901, 'UPDATE', 'Test Catalogue']],
+            sheet_name='Work',  # uppercase — standard upload
+        )
+        # Standard upload requires all 5 mandatory sheets; this will raise an error
+        with self.assertRaises(CofkExcelFileError):
+            CofkUploadExcelFile(self.new_upload, path)
+
+    # --- Parsing: success cases ---
+
+    def test_valid_row_creates_correction_record(self):
+        """A valid data row creates a CofkCollectWorkCorrection with the correct corrections dict."""
+        path = self._make_file(
+            CORRECTION_HEADERS,
+            [[9901, 'UPDATE', 'Test Catalogue']],
+        )
+        CofkUploadExcelFile(self.new_upload, path)
+        correction = CofkCollectWorkCorrection.objects.get(upload=self.new_upload, iwork_id=9901)
+        self.assertEqual(correction.corrections, {'original_catalogue_code': 'TESTCAT'})
+        self.assertEqual(correction.upload_status_id, 1)
+
+    def test_union_work_fk_set_on_correction_record(self):
+        """The union_work FK is populated when the iwork_id is found."""
+        path = self._make_file(
+            CORRECTION_HEADERS,
+            [[9901, 'UPDATE', 'Test Catalogue']],
+        )
+        CofkUploadExcelFile(self.new_upload, path)
+        correction = CofkCollectWorkCorrection.objects.get(upload=self.new_upload, iwork_id=9901)
+        self.assertEqual(correction.union_work_id, 9901)
+
+    def test_multiple_correction_columns_stored(self):
+        """All recognised correction columns in a row are included in the corrections dict."""
+        headers = ['EMLO Letter ID Number', 'Command', 'Abstract', 'Keywords']
+        path = self._make_file(
+            headers,
+            [[9901, 'UPDATE', 'A new abstract', 'keyword1; keyword2']],
+        )
+        CofkUploadExcelFile(self.new_upload, path)
+        correction = CofkCollectWorkCorrection.objects.get(upload=self.new_upload, iwork_id=9901)
+        self.assertEqual(correction.corrections['abstract'], 'A new abstract')
+        self.assertEqual(correction.corrections['keywords'], 'keyword1; keyword2')
+
+    def test_multiple_rows_create_multiple_records(self):
+        """Two valid rows produce two CofkCollectWorkCorrection objects."""
+        path = self._make_file(
+            ['EMLO Letter ID Number', 'Abstract'],
+            [[9901, 'Abstract one'], [9902, 'Abstract two']],
+        )
+        CofkUploadExcelFile(self.new_upload, path)
+        self.assertEqual(
+            CofkCollectWorkCorrection.objects.filter(upload=self.new_upload).count(), 2
+        )
+
+    def test_upload_total_works_set(self):
+        """upload.total_works is set to the number of parsed corrections (in-memory, saved by handle_upload)."""
+        path = self._make_file(
+            ['EMLO Letter ID Number', 'Abstract'],
+            [[9901, 'Abstract one'], [9902, 'Abstract two']],
+        )
+        CofkUploadExcelFile(self.new_upload, path)
+        self.assertEqual(self.new_upload.total_works, 2)
+
+    # --- Parsing: catalogue FK lookup ---
+
+    def test_valid_catalogue_lookup_stores_code(self):
+        """'Original Catalogue name' is resolved to catalogue_code stored as original_catalogue_code."""
+        path = self._make_file(
+            CORRECTION_HEADERS,
+            [[9901, 'UPDATE', 'Test Catalogue']],
+        )
+        CofkUploadExcelFile(self.new_upload, path)
+        correction = CofkCollectWorkCorrection.objects.get(upload=self.new_upload, iwork_id=9901)
+        self.assertIn('original_catalogue_code', correction.corrections)
+        self.assertEqual(correction.corrections['original_catalogue_code'], 'TESTCAT')
+        self.assertNotIn('original_catalogue', correction.corrections)
+
+    def test_unknown_catalogue_produces_error(self):
+        """An unrecognised catalogue name produces a validation error."""
+        path = self._make_file(
+            CORRECTION_HEADERS,
+            [[9901, 'UPDATE', 'NonExistentCatalogue']],
+        )
+        cuef = CofkUploadExcelFile(self.new_upload, path)
+        self.assertGreater(cuef.total_errors, 0)
+        self.assertEqual(CofkCollectWorkCorrection.objects.filter(upload=self.new_upload).count(), 0)
+
+    # --- Parsing: validation errors ---
+
+    def test_nonexistent_iwork_id_produces_error(self):
+        """An iwork_id not in CofkUnionWork produces a validation error and no record."""
+        path = self._make_file(
+            ['EMLO Letter ID Number', 'Abstract'],
+            [[99999, 'Some abstract']],
+        )
+        cuef = CofkUploadExcelFile(self.new_upload, path)
+        self.assertGreater(cuef.total_errors, 0)
+        self.assertEqual(CofkCollectWorkCorrection.objects.filter(upload=self.new_upload).count(), 0)
+
+    def test_non_integer_identifier_produces_error(self):
+        """A non-integer value in the identifier column produces a validation error."""
+        path = self._make_file(
+            ['EMLO Letter ID Number', 'Abstract'],
+            [['notanumber', 'Some abstract']],
+        )
+        cuef = CofkUploadExcelFile(self.new_upload, path)
+        self.assertGreater(cuef.total_errors, 0)
+
+    def test_invalid_command_produces_error(self):
+        """A Command value other than UPDATE produces a validation error."""
+        path = self._make_file(
+            ['EMLO Letter ID Number', 'Command', 'Abstract'],
+            [[9901, 'DELETE', 'Some abstract']],
+        )
+        cuef = CofkUploadExcelFile(self.new_upload, path)
+        self.assertGreater(cuef.total_errors, 0)
+
+    def test_invalid_bool_field_produces_error(self):
+        """A value of 2 for a boolean field produces a validation error."""
+        path = self._make_file(
+            ['EMLO Letter ID Number', 'Date inferred (0=No; 1=Yes)'],
+            [[9901, 2]],
+        )
+        cuef = CofkUploadExcelFile(self.new_upload, path)
+        self.assertGreater(cuef.total_errors, 0)
+
+    def test_year_out_of_range_produces_error(self):
+        """A year outside 1400-1900 produces a validation error."""
+        path = self._make_file(
+            ['EMLO Letter ID Number', 'Year date'],
+            [[9901, 2025]],
+        )
+        cuef = CofkUploadExcelFile(self.new_upload, path)
+        self.assertGreater(cuef.total_errors, 0)
+
+    def test_row_with_no_correction_columns_skipped(self):
+        """A row containing only the identifier (no correction fields) is skipped; upload fails with no valid rows."""
+        path = self._make_file(
+            ['EMLO Letter ID Number'],
+            [[9901]],
+        )
+        with self.assertRaises(CofkExcelFileError):
+            CofkUploadExcelFile(self.new_upload, path)
+        self.assertEqual(CofkCollectWorkCorrection.objects.filter(upload=self.new_upload).count(), 0)
+
+    def test_duplicate_iwork_id_only_first_kept(self):
+        """Two rows with the same iwork_id result in only one CofkCollectWorkCorrection."""
+        path = self._make_file(
+            ['EMLO Letter ID Number', 'Abstract'],
+            [[9901, 'First abstract'], [9901, 'Second abstract']],
+        )
+        CofkUploadExcelFile(self.new_upload, path)
+        self.assertEqual(
+            CofkCollectWorkCorrection.objects.filter(upload=self.new_upload, iwork_id=9901).count(), 1
+        )
+        correction = CofkCollectWorkCorrection.objects.get(upload=self.new_upload, iwork_id=9901)
+        self.assertEqual(correction.corrections['abstract'], 'First abstract')
+
+    def test_empty_sheet_raises_error(self):
+        """A corrections sheet with no data rows raises CofkExcelFileError."""
+        path = self._make_file(CORRECTION_HEADERS, [])
+        with self.assertRaises(CofkExcelFileError):
+            CofkUploadExcelFile(self.new_upload, path)
+
+    # --- Accept/Reject ---
+
+    def test_accept_corrections_applies_field_values(self):
+        """accept_corrections() updates CofkUnionWork with the new field values."""
+        CofkCollectWorkCorrection.objects.create(
+            upload=self.new_upload,
+            iwork_id=9901,
+            union_work=self.test_work,
+            corrections={'abstract': 'Corrected abstract'},
+            upload_status_id=1,
+        )
+        accept_corrections(self.new_upload, username='testuser')
+        self.test_work.refresh_from_db()
+        self.assertEqual(self.test_work.abstract, 'Corrected abstract')
+
+    def test_accept_corrections_sets_change_user(self):
+        """accept_corrections() stamps the change_user on the updated work."""
+        CofkCollectWorkCorrection.objects.create(
+            upload=self.new_upload,
+            iwork_id=9901,
+            union_work=self.test_work,
+            corrections={'abstract': 'Changed'},
+            upload_status_id=1,
+        )
+        accept_corrections(self.new_upload, username='reviewer42')
+        self.test_work.refresh_from_db()
+        self.assertEqual(self.test_work.change_user, 'reviewer42')
+
+    def test_accept_corrections_applies_catalogue_fk(self):
+        """original_catalogue_code in corrections is correctly applied as original_catalogue_id."""
+        CofkCollectWorkCorrection.objects.create(
+            upload=self.new_upload,
+            iwork_id=9901,
+            union_work=self.test_work,
+            corrections={'original_catalogue_code': 'TESTCAT'},
+            upload_status_id=1,
+        )
+        accept_corrections(self.new_upload, username='testuser')
+        self.test_work.refresh_from_db()
+        self.assertEqual(self.test_work.original_catalogue_id, 'TESTCAT')
+
+    def test_accept_corrections_sets_upload_status_accepted(self):
+        """After accept_corrections(), upload.upload_status_id == 4."""
+        CofkCollectWorkCorrection.objects.create(
+            upload=self.new_upload,
+            iwork_id=9901,
+            union_work=self.test_work,
+            corrections={'abstract': 'Changed'},
+            upload_status_id=1,
+        )
+        accept_corrections(self.new_upload, username='testuser')
+        self.new_upload.refresh_from_db()
+        self.assertEqual(self.new_upload.upload_status_id, 4)
+
+    def test_accept_corrections_sets_correction_status_accepted(self):
+        """After accept_corrections(), each CofkCollectWorkCorrection.upload_status_id == 4."""
+        correction = CofkCollectWorkCorrection.objects.create(
+            upload=self.new_upload,
+            iwork_id=9901,
+            union_work=self.test_work,
+            corrections={'abstract': 'Changed'},
+            upload_status_id=1,
+        )
+        accept_corrections(self.new_upload, username='testuser')
+        correction.refresh_from_db()
+        self.assertEqual(correction.upload_status_id, 4)
+
+    def test_reject_corrections_sets_status_rejected(self):
+        """reject_corrections() sets correction records to status 5 and upload to status 3."""
+        correction = CofkCollectWorkCorrection.objects.create(
+            upload=self.new_upload,
+            iwork_id=9901,
+            union_work=self.test_work,
+            corrections={'abstract': 'Changed'},
+            upload_status_id=1,
+        )
+        reject_corrections(self.new_upload)
+        correction.refresh_from_db()
+        self.new_upload.refresh_from_db()
+        self.assertEqual(correction.upload_status_id, 5)
+        self.assertEqual(self.new_upload.upload_status_id, 3)
+
+    def test_accept_corrections_does_not_modify_work_when_none(self):
+        """accept_corrections() skips a correction whose union_work is None (work was deleted)."""
+        CofkCollectWorkCorrection.objects.create(
+            upload=self.new_upload,
+            iwork_id=99999,
+            union_work=None,
+            corrections={'abstract': 'Changed'},
+            upload_status_id=1,
+        )
+        # Should not raise; applied count will be 0
+        accept_corrections(self.new_upload, username='testuser')
+        self.new_upload.refresh_from_db()
+        self.assertEqual(self.new_upload.upload_status_id, 4)
+        self.assertEqual(self.new_upload.works_accepted, 0)

--- a/uploader/test/test_corrections.py
+++ b/uploader/test/test_corrections.py
@@ -14,6 +14,7 @@ from work.models import CofkUnionWork
 log = logging.getLogger(__name__)
 
 CORRECTION_HEADERS = ['EMLO Letter ID Number', 'Command', 'Original Catalogue name']
+CORRECTION_ROW = [9901, 'UPDATE', 'TESTCAT']  # TESTCAT is the catalogue_code, not the name
 
 
 class TestCorrectionUpload(UploadIncludedFactoryTestCase):
@@ -43,7 +44,7 @@ class TestCorrectionUpload(UploadIncludedFactoryTestCase):
     def tearDown(self):
         super().tearDown()
 
-    def _make_file(self, header_row, data_rows, sheet_name='work'):
+    def _make_file(self, header_row, data_rows, sheet_name='Corrections'):
         wb = Workbook()
         ws = wb.create_sheet(sheet_name)
         ws.append(header_row)
@@ -60,7 +61,7 @@ class TestCorrectionUpload(UploadIncludedFactoryTestCase):
         """Lowercase 'work' sheet is detected as 'correction' upload type."""
         path = self._make_file(
             CORRECTION_HEADERS,
-            [[9901, 'UPDATE', 'Test Catalogue']],
+            [CORRECTION_ROW],
         )
         cuef = CofkUploadExcelFile(self.new_upload, path)
         self.assertEqual(cuef.upload_type, 'correction')
@@ -69,7 +70,7 @@ class TestCorrectionUpload(UploadIncludedFactoryTestCase):
         """Uppercase 'Work' sheet is NOT treated as correction upload."""
         path = self._make_file(
             CORRECTION_HEADERS,
-            [[9901, 'UPDATE', 'Test Catalogue']],
+            [CORRECTION_ROW],
             sheet_name='Work',  # uppercase — standard upload
         )
         # Standard upload requires all 5 mandatory sheets; this will raise an error
@@ -82,7 +83,7 @@ class TestCorrectionUpload(UploadIncludedFactoryTestCase):
         """A valid data row creates a CofkCollectWorkCorrection with the correct corrections dict."""
         path = self._make_file(
             CORRECTION_HEADERS,
-            [[9901, 'UPDATE', 'Test Catalogue']],
+            [CORRECTION_ROW],
         )
         CofkUploadExcelFile(self.new_upload, path)
         correction = CofkCollectWorkCorrection.objects.get(upload=self.new_upload, iwork_id=9901)
@@ -93,7 +94,7 @@ class TestCorrectionUpload(UploadIncludedFactoryTestCase):
         """The union_work FK is populated when the iwork_id is found."""
         path = self._make_file(
             CORRECTION_HEADERS,
-            [[9901, 'UPDATE', 'Test Catalogue']],
+            [CORRECTION_ROW],
         )
         CofkUploadExcelFile(self.new_upload, path)
         correction = CofkCollectWorkCorrection.objects.get(upload=self.new_upload, iwork_id=9901)
@@ -137,7 +138,7 @@ class TestCorrectionUpload(UploadIncludedFactoryTestCase):
         """'Original Catalogue name' is resolved to catalogue_code stored as original_catalogue_code."""
         path = self._make_file(
             CORRECTION_HEADERS,
-            [[9901, 'UPDATE', 'Test Catalogue']],
+            [CORRECTION_ROW],
         )
         CofkUploadExcelFile(self.new_upload, path)
         correction = CofkCollectWorkCorrection.objects.get(upload=self.new_upload, iwork_id=9901)
@@ -149,7 +150,7 @@ class TestCorrectionUpload(UploadIncludedFactoryTestCase):
         """An unrecognised catalogue name produces a validation error."""
         path = self._make_file(
             CORRECTION_HEADERS,
-            [[9901, 'UPDATE', 'NonExistentCatalogue']],
+            [[9901, 'UPDATE', 'BADCODE']],
         )
         cuef = CofkUploadExcelFile(self.new_upload, path)
         self.assertGreater(cuef.total_errors, 0)

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -24,8 +24,9 @@ from core.helper.uploader_serv import handle_upload, file_path_and_size
 from core.helper.view_serv import DefaultSearchView
 from core.models import CofkLookupCatalogue, CofkLookupDocumentType
 from uploader.forms import CofkCollectUploadForm, GeneralSearchFieldset
-from uploader.models import CofkCollectUpload, CofkCollectPerson, CofkCollectLocation
-from uploader.review import reject_works, accept_people, reject_people, accept_locations, reject_locations
+from uploader.models import CofkCollectUpload, CofkCollectPerson, CofkCollectLocation, CofkCollectWorkCorrection
+from uploader.review import reject_works, accept_people, reject_people, accept_locations, reject_locations, \
+    accept_corrections, reject_corrections
 from uploader.uploader_serv import DisplayableCollectWork
 
 log = logging.getLogger(__name__)
@@ -121,6 +122,8 @@ def upload_review(request, upload_id, **kwargs):
         return _upload_review_people(request, upload)
     elif upload.upload_type == 'location':
         return _upload_review_locations(request, upload)
+    elif upload.upload_type == 'correction':
+        return _upload_review_corrections(request, upload)
 
     return _upload_review_works(request, upload)
 
@@ -216,6 +219,48 @@ def _upload_review_locations(request, upload: CofkCollectUpload):
         'locations': locations,
     }
     return render(request, 'uploader/review_locations.html', context)
+
+
+def _upload_review_corrections(request, upload: CofkCollectUpload):
+    if 'confirm' in request.POST and 'action' in request.POST:
+        if request.POST['action'] == 'accept':
+            accept_corrections(upload, request.user.username, request)
+            return redirect(reverse('uploader:upload_list'))
+        elif request.POST['action'] == 'reject':
+            reject_corrections(upload, request)
+            return redirect(reverse('uploader:upload_list'))
+
+    corrections = (
+        CofkCollectWorkCorrection.objects
+        .filter(upload=upload)
+        .select_related('union_work', 'union_work__original_catalogue')
+        .order_by('iwork_id')
+    )
+
+    # Build a flat list of rows for the template: one entry per (correction × field).
+    correction_rows = []
+    for correction in corrections:
+        work_id = correction.union_work.work_id if correction.union_work else None
+        work_desc = (correction.union_work.description or work_id) if correction.union_work else None
+        for field_name, new_value in correction.corrections.items():
+            actual_field = 'original_catalogue_id' if field_name == 'original_catalogue_code' else field_name
+            old_value = getattr(correction.union_work, actual_field, None) if correction.union_work else None
+            correction_rows.append({
+                'iwork_id': correction.iwork_id,
+                'work_id': work_id,
+                'work_desc': work_desc,
+                'field': field_name,
+                'old_value': old_value,
+                'new_value': new_value,
+            })
+
+    context = {
+        'upload': upload,
+        'corrections': corrections,
+        'correction_rows': correction_rows,
+        'corrections_count': corrections.count(),
+    }
+    return render(request, 'uploader/review_corrections.html', context)
 
 
 def lookup_fn_date_of_work(lookup_fn, field_name, value):


### PR DESCRIPTION
### Bulk corrections upload

Adds a fourth upload type to the uploader app — correction — which allows curators to apply bulk corrections to existing CofkUnionWork records via a spreadsheet, using the same staging → review → accept/reject flow as the existing work, people, and location uploads.

Spreadsheet format

- Sheet name: **Corrections** (distinguishes it from the standard Work upload)
- One header row (not two)
- Column 1: EMLO Letter ID Number — maps to CofkUnionWork.iwork_id
- Column 2: Command — must be UPDATE (only supported command)
- Remaining columns: any subset of the 34 correctable fields; unrecognised columns are silently ignored

Supported fields

Dates, calendar, date flags, author/recipient/origin/destination "as marked" strings and inferred/uncertain flags, abstract, keywords, incipit, explicit, notes, catalogue (by catalogue_code), accession code, and editors' notes. Relationship fields (author/recipient EMLO IDs, languages, people mentioned, resources) are excluded from this MVP as they require many-to-many table changes.

Changes

- uploader/constants.py — Added CORRECTION_WORK_SHEET: column-to-field mapping, type lists (ints, bools, years, months, dates, FK fields)
- uploader/models.py — Added CofkCollectWorkCorrection staging model with JSONField for variable corrections per row
- uploader/entities/corrections.py — New CofkWorkCorrections parser: validates types, bools, year/month/day ranges, catalogue code FK
- uploader/spreadsheet.py — Detection (Corrections sheet → 'correction' type) and _process_correction_upload()
- uploader/review.py — accept_corrections() and reject_corrections()
- uploader/views.py — _upload_review_corrections() view, builds flat per-field rows showing old vs proposed values
- uploader/templates/uploader/review_corrections.html — Review template with Accept/Reject confirm flow
- uploader/migrations/0010_cofkcollectworkcorrection.py — Migration for new staging table
- uploader/test/test_corrections.py — 24 unit tests covering detection, parsing, validation, FK lookup, accept, and reject
- docker/site-edit-2/docker-entrypoint-unittest.sh — Added --keepdb to prevent test DB creation failure on restart

Validation

Errors during parsing block the entire upload (consistent with existing upload types):

- Non-integer or missing EMLO Letter ID Number
- iwork_id not found in CofkUnionWork
- Command value other than UPDATE
- Invalid bool fields (must be 0 or 1)
- Year outside 1400–1900, month outside 1–12, day > 31
- catalogue_code not found in CofkLookupCatalogue

Duplicate iwork_id rows: first occurrence wins, subsequent rows are skipped with a log warning.

Notes

- original_catalogue is stored as original_catalogue_code (the FK string value) in the JSONField and applied as original_catalogue_id at accept time — avoids serialising a FK object into JSON.
- DatabaseTweaker (SQLAlchemy) is not used for acceptance; Django ORM is used throughout for transactional correctness and change_user/change_timestamp stamping, consistent with accept_people() and accept_locations().
- The old PHP EMLO system (upload.php) designed three commands — CREATE, UPDATE, DELETE — but only UPDATE was ever implemented. This implementation follows the same precedent.


This PR was done with the help of Claude